### PR TITLE
table alias: make really unique

### DIFF
--- a/src/queryASTToSqlAST.js
+++ b/src/queryASTToSqlAST.js
@@ -191,7 +191,9 @@ function stripNonNullType(type) {
 function makeUnique(usedNames, name) {
   if (usedNames.has(name)) {
     name += '$'
+    return makeUnique(usedNames, name)
   }
+
   usedNames.add(name)
   return name
 }


### PR DESCRIPTION
If the alias has already been made on the field once it won't be truly
unique. This will recursively make it unique. Also, it will probably
create a humongous query.
