### PR TITLE
Guard against empty node results

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -102,6 +102,10 @@ function getNode(typeName, resolveInfo, context, where, dbCall, options = {}) {
   pruneDuplicateSqlDeps(sqlAST, namespace)
   const { sql, shapeDefinition } = compileSqlAST(sqlAST, context, options)
   return handleUserDbCall(dbCall, sql, shapeDefinition, sqlAST).then(obj => {
+    // if no data is returned, just return the null response
+    if (!obj) {
+      return obj
+    }
     // after we get the data, slap the Type on there to assist with determining the type
     obj.__type__ = type
     return obj

--- a/test/relay.js
+++ b/test/relay.js
@@ -1,5 +1,6 @@
 import test from 'ava'
 import { graphql } from 'graphql'
+import { toGlobalId } from 'graphql-relay'
 import schemaRelay from '../example/schema-relay-standard/index'
 import { partial } from 'lodash'
 
@@ -72,6 +73,25 @@ test('it should fetch a Node type with a variable', async t => {
     node: {
       fullName: 'andrew carlson',
     }
+  }
+  t.deepEqual(data, expect)
+})
+
+test('it should not error when no record is returned ', async t => {
+  const query = `
+    query node($id: ID!){
+      node(id: $id) {
+        ...on User {
+          fullName
+        }
+      }
+    }
+  `
+  const variables = { id: toGlobalId('User', 999) }
+  const { data, errors } = await graphql(schemaRelay, query, null, null, variables)
+  t.is(errors, undefined)
+  const expect = {
+    node: null
   }
   t.deepEqual(data, expect)
 })


### PR DESCRIPTION
I noticed that if my database call returned null when fetching a node, a TypeError was thrown. This fixes it.
