### PR TITLE
Allows where attribute to return an array, and have it correctly concatinated.

### DIFF
--- a/src/stringifiers/mysql.js
+++ b/src/stringifiers/mysql.js
@@ -26,10 +26,12 @@ async function _stringifySqlAST(parent, node, prefix, context, selections, joins
     // generate the "where" condition, if applicable
     if (node.where) {
       const whereCondition = await node.where(`${quote(node.as)}`, node.args || {}, context)
-      if( whereCondition instanceof Array ) {
-        wheres = wheres.concat( whereCondition )
-      } else {
-        wheres.push(`${whereCondition}`)
+      if (whereCondition) {
+        if( whereCondition instanceof Array ) {
+          wheres = wheres.concat( whereCondition )
+        } else {
+          wheres.push(`${whereCondition}`)
+        }
       }
     }
 

--- a/src/stringifiers/mysql.js
+++ b/src/stringifiers/mysql.js
@@ -25,8 +25,10 @@ async function _stringifySqlAST(parent, node, prefix, context, selections, joins
   case 'table':
     // generate the "where" condition, if applicable
     if (node.where) {
-      const whereCondition = await node.where(`${quote(node.as)}`, node.args || {}, context) 
-      if (whereCondition) {
+      const whereCondition = await node.where(`${quote(node.as)}`, node.args || {}, context)
+      if( whereCondition instanceof Array ) {
+        wheres = wheres.concat( whereCondition )
+      } else {
         wheres.push(`${whereCondition}`)
       }
     }
@@ -94,4 +96,3 @@ async function _stringifySqlAST(parent, node, prefix, context, selections, joins
 function quote(str) {
   return '`' + str + '`'
 }
-

--- a/src/stringifiers/pg.js
+++ b/src/stringifiers/pg.js
@@ -32,10 +32,12 @@ async function _stringifySqlAST(parent, node, prefix, context, selections, joins
     // generate the "where" condition, if applicable
     if (node.where && !node.paginate) {
       const whereCondition = await node.where(`"${node.as}"`, node.args || {}, context)
-      if( whereCondition instanceof Array ) {
-        wheres = wheres.concat( whereCondition )
-      } else {
-        wheres.push(`${whereCondition}`)
+      if (whereCondition) {
+        if( whereCondition instanceof Array ) {
+          wheres = wheres.concat( whereCondition )
+        } else {
+          wheres.push(`${whereCondition}`)
+        }
       }
     }
 

--- a/src/stringifiers/pg.js
+++ b/src/stringifiers/pg.js
@@ -12,7 +12,7 @@ export default async function stringifySqlAST(topNode, context) {
   // GraphQL does not prevent queries with duplicate fields
   selections = [ ...new Set(selections) ]
 
-  // bail out if they made no selections 
+  // bail out if they made no selections
   if (!selections.length) return ''
 
   // put together the SQL query
@@ -32,7 +32,9 @@ async function _stringifySqlAST(parent, node, prefix, context, selections, joins
     // generate the "where" condition, if applicable
     if (node.where && !node.paginate) {
       const whereCondition = await node.where(`"${node.as}"`, node.args || {}, context)
-      if (whereCondition) {
+      if( whereCondition instanceof Array ) {
+        wheres = wheres.concat( whereCondition )
+      } else {
         wheres.push(`${whereCondition}`)
       }
     }
@@ -46,7 +48,7 @@ async function _stringifySqlAST(parent, node, prefix, context, selections, joins
       if (node.paginate) {
         let whereCondition = node.sqlJoin(`"${parent.as}"`, node.name)
         if (node.where) {
-          const filterCondition = await node.where(`${node.name}`, node.args || {}, context) 
+          const filterCondition = await node.where(`${node.name}`, node.args || {}, context)
           if (filterCondition) {
             whereCondition += ' AND ' + filterCondition
           }
@@ -95,7 +97,7 @@ LEFT JOIN LATERAL (
           `LEFT JOIN ${node.name} AS "${node.as}" ON ${joinCondition}`
         )
       }
-    
+
     // this branch is for many-to-many relations, needs two joins
     } else if (node.joinTable) {
       if (!node.sqlJoins) throw new Error('Must set "sqlJoins" for a join table.')
@@ -105,7 +107,7 @@ LEFT JOIN LATERAL (
       if (node.paginate) {
         let whereCondition = node.sqlJoins[0](`"${parent.as}"`, node.joinTable)
         if (node.where) {
-          const filterCondition = await node.where(`${node.name}`, node.args || {}, context) 
+          const filterCondition = await node.where(`${node.name}`, node.args || {}, context)
           if (filterCondition) {
             whereCondition += ' AND ' + filterCondition
           }
@@ -162,7 +164,7 @@ LEFT JOIN LATERAL (
         let { limit, orderColumns, whereCondition } = interpretForKeysetPaging(node)
         whereCondition = whereCondition || 'TRUE'
         if (node.where) {
-          const filterCondition = await node.where(`${node.name}`, node.args || {}, context) 
+          const filterCondition = await node.where(`${node.name}`, node.args || {}, context)
           if (filterCondition) {
             whereCondition += ' AND ' + filterCondition
           }
@@ -183,7 +185,7 @@ FROM (
         const { limit, offset, orderColumns } = interpretForOffsetPaging(node)
         let whereCondition = 'TRUE'
         if (node.where) {
-          const filterCondition = await node.where(`${node.name}`, node.args || {}, context) 
+          const filterCondition = await node.where(`${node.name}`, node.args || {}, context)
           if (filterCondition) {
             whereCondition = filterCondition
           }
@@ -365,4 +367,3 @@ function validateCursor(cursorObj, expectedKeys) {
     }
   }
 }
-

--- a/src/stringifiers/standard.js
+++ b/src/stringifiers/standard.js
@@ -27,7 +27,11 @@ async function _stringifySqlAST(parent, node, prefix, context, selections, joins
     if (node.where) {
       const whereCondition = await node.where(`"${node.as}"`, node.args || {}, context)
       if (whereCondition) {
-        wheres.push(`${whereCondition}`)
+        if( whereCondition instanceof Array ) {
+          wheres = wheres.concat( whereCondition )
+        } else {
+          wheres.push(`${whereCondition}`)
+        }
       }
     }
 
@@ -90,4 +94,3 @@ async function _stringifySqlAST(parent, node, prefix, context, selections, joins
   }
   return { selections, joins, wheres }
 }
-


### PR DESCRIPTION
The codebase appeared to allow for an array of where conditions but didn't comply to it fully. This pull request addresses this.


```
 fields: () => ({
      user: {
        type: new GraphQLList( User ),
        args: { id: { type: GraphQLInt }, username: { type: GraphQLString }, password: { type: GraphQLString } },
        where: ( usersTable, args, context ) => {
          
          var wheres = [];
          if( args.id )         wheres.push( `${usersTable}.id = ${args.id}` );
          if( args.username )   wheres.push( `${usersTable}.username = "${args.username}"` );
          if( args.password )   wheres.push( `${usersTable}.password = "` + crypto.createHash( 'sha1' ).update( args.password ).digest( 'hex' ) + `"` );

          return wheres;
        },
      },
```