### PR TITLE
Expose a getSQL method

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -56,6 +56,26 @@ async function joinMonster(resolveInfo, context, dbCall, options = {}) {
   return handleUserDbCall(dbCall, sql, shapeDefinition, sqlAST)
 }
 
+/**
+ * Takes the GraphQL AST and returns an SQL query
+ * @param {Object} resolveInfo - Contains the parsed GraphQL query, schema definition, and more. Obtained from the fourth argument to the resolver.
+ * @param {Object} context - An arbitrary object that gets passed to the `where` function. Useful for contextual infomation that influeces the  `WHERE` condition, e.g. session, logged in user, localization.
+ * @param {Object} [options]
+ * @param {Boolean} options.minify - Generate minimum-length column names in the results table.
+ * @param {String} options.dialect - The dialect of SQL your Database uses. Currently `'pg'`, `'mysql'`, and `'standard'` are supported.
+ * @returns {Promise<string>} The SQL query generated
+ */
+async function getSQL(resolveInfo, context, options = {}) {
+  // same as above
+  const sqlAST = queryASTToSqlAST(resolveInfo, options)
+  const { sql } = await compileSqlAST(sqlAST, context, options)
+  if (!sql) return Promise.resolve({})
+
+  return sql
+}
+
+joinMonster.getSQL = getSQL
+
 async function compileSqlAST(sqlAST, context, options) {
   debug(emphasize('SQL_AST'), inspect(sqlAST))
 
@@ -165,4 +185,3 @@ function validate(rows) {
 // expose the package version for debugging
 joinMonster.version = require('../package.json').version
 export default joinMonster
-


### PR DESCRIPTION
Hey !

First of all, thank you for the time you spent on this project, love what you did :)

Backstory : 
I have a table holding a list of places, one of the fields is the GPS coordinates of the place.
In my GraphQL schema, I needed to expose a `distance` field for each place, representing the distance between a given point (expected as argument), and the current place.

Since that field doesn't exist in my database, I wanted to use the query generated by Join Monster as a nested query, compute the `distance` field on the fly and return it as if it existed in the model.

I ended up adding a new method that simply returns the computed SQL query, I thought it might be used as a fallback in edge cases like this one.

Anyways, let me know what you think :)
