### PR TITLE
More generic Node interface support

### DIFF
--- a/docs/relay.md
+++ b/docs/relay.md
@@ -41,9 +41,14 @@ const { nodeInterface, nodeField } = nodeDefinitions(
   (globalId, context, resolveInfo) => {
     // parse the globalID
     const { type, id } = fromGlobalId(globalId)
+
+    // get name of unique key defined on table
+    // NOTE: This does not work with composite keys
+    const uniqueKey = resolveInfo.schema.getType(type)._typeConfig.uniqueKey;
+
     // pass the type name and other info. `joinMonster` will find the type from the name and write the SQL
     return joinMonster.getNode(type, resolveInfo, context,
-      table => `${table}.id = ${id}`,
+      table => `${table}.${uniqueKey} = ${id}`,
       sql => knex.raw(sql)
     )
   },


### PR DESCRIPTION
Hi, I found quick solution for generic `Node` interface support.

### Not perfect:
- [ ] it probably fails when `uniqueKey` is array — composite key
- [ ] it does not handle SQL identifier escaping
- [ ] it looks into GraphQL internals

```js
const { nodeInterface, nodeField } = nodeDefinitions(
  // resolve the ID to an object
  (globalId, context, resolveInfo) => {
    // parse the globalID
    const { type, id } = fromGlobalId(globalId)

    // get name of unique key defined on table
    // NOTE: This does not work with composite keys
    const uniqueKey = resolveInfo.schema.getType(type)._typeConfig.uniqueKey;

    // pass the type name and other info. `joinMonster` will find the type from the name and write the SQL
    return joinMonster.getNode(type, resolveInfo, context,
      table => `${table}.${uniqueKey} = ${id}`,
      sql => knex.raw(sql)
    )
  },
  // determines the type. Join Monster places that type onto the result object on the "__type__" property
  obj => obj.__type__
)
```