### PR TITLE
Add interface support

### DIFF
--- a/src/queryASTToSqlAST.js
+++ b/src/queryASTToSqlAST.js
@@ -176,8 +176,10 @@ function handleSelections(children, selections, gqlType, fragments, variables, n
     case 'FragmentSpread':
       const fragmentName = selection.name.value
       const fragment = fragments[fragmentName]
-      // make sure fragment type matches the type being queried
-      if (fragment.typeCondition.name.value === gqlType.name) {
+      // make sure fragment type matches the type being queried OR its interfaces
+      const sameType = fragment.typeCondition.name.value === gqlType.name
+      const interfaceType = gqlType._interfaces.map(iface => iface.name).indexOf(fragment.typeCondition.name.value) >= 0
+      if (sameType || interfaceType) {
         handleSelections(children, fragment.selectionSet.selections, gqlType, fragments, variables, namespace, options)
       }
       break


### PR DESCRIPTION
I've been playing with this and it looks very nice. Great work! It's just what I've been looking for since I've started learning GraphQL, and I'd like to make a small code contribution towards interface support.

**Test scenario**

Suppose we have a hierarchy of work groups. Direccion has many Gerencias, which in turn has many Jefaturas and Jefaturas have Celulas. Every work group has its own fields but it also implements the interface Agrupacion, which has fields "id" and "nombre". You can check the schema [here](https://github.com/stems/join-monster/files/690675/schema.zip).

```js
// Interface definition
const Agrupacion = new GraphQLInterfaceType({
  name: 'Agrupacion',
  fields: {
    id: { type: GraphQLInt },
    nombre: { type: GraphQLString }
  }
});
// Type definition
const Gerencia = new GraphQLObjectType({
  interfaces: () => [ Agrupacion ], // list of interfaces; can be an array or thunk
  name: 'Gerencia',
  sqlTable: 'GERENCIAS',
  uniqueKey: 'cd_gerencia',
  fields: () => ({
    id: {
      type: GraphQLInt,
      sqlColumn: 'cd_gerencia'
    },
    nombre: {
      type: GraphQLString,
      sqlColumn: 'tx_gerencia'
    },
    direccion: {
      type: GraphQLInt,
      sqlColumn: 'cd_direccion'
    },
    jefaturas: {
      type: new GraphQLList(Jefatura),
      sqlJoin(gerenciaTable, jefaturaTable) {
        return `${gerenciaTable}.cd_gerencia = ${jefaturaTable}.cd_gerencia`
      }
    }
  }),
  isTypeOf: (value, info) => typeof value.cd_gerencia !== "undefined" // helper to get the right type
});
// other type definitions
//...
```
I've been reading the code in `queryASTToSqlAST.js` and it looked like if you just compare the fragment type with the object type OR the interface types it implements, it should just work.
After applying this change, everything seems to work fine with InlineFragment and FragmentSpread. 
There are no breaking changes because it makes use of GraphQLObjectType properties which are already there: `interfaces `and `isTypeOf`.


**Example (working) query**
```
query getGerencias($id: Int, $nombre: String) {
  gerencia(id: $id, name: $nombre) {
    ...nodeData
    jefaturas {
      ...nodeData
      celulas {
        ...nodeData
        jefatura
      }
    }
  }
}

fragment nodeData on Agrupacion {
  id
  nombre
  ...on Gerencia {
    direccion
  }
  ...on Jefatura {
    gerencia
  }
  ...on Celula {
    jefatura
  }
}

```

It looks like this:
![captura_de_pantalla_010617_041230_pm](https://cloud.githubusercontent.com/assets/819697/21729783/6686bd68-d42b-11e6-8cee-a76152b03754.jpg)




