### PR TITLE
Fix Order by GraphQLInputObjectType

### DIFF
--- a/src/query-ast-to-sql-ast/index.js
+++ b/src/query-ast-to-sql-ast/index.js
@@ -475,6 +475,10 @@ function parseArgValue(value, variableValues) {
     return parseFloat(value.value)
   case 'ListValue':
     return value.values.map(value => parseArgValue(value, variableValues))
+  case 'ObjectValue':
+    return value.fields.map(value => parseArgValue(value, variableValues));
+  case 'ObjectField':
+    return {[value.name.value]:name,value:value.value.value};
   default:
     return value.value
   }

--- a/src/query-ast-to-sql-ast/index.js
+++ b/src/query-ast-to-sql-ast/index.js
@@ -478,7 +478,7 @@ function parseArgValue(value, variableValues) {
   case 'ObjectValue':
     return value.fields.map(value => parseArgValue(value, variableValues));
   case 'ObjectField':
-    return {[value.name.value]:name,value:value.value.value};
+    return {name:value.name.value,value:value.value.value};
   default:
     return value.value
   }

--- a/src/query-ast-to-sql-ast/index.js
+++ b/src/query-ast-to-sql-ast/index.js
@@ -476,9 +476,9 @@ function parseArgValue(value, variableValues) {
   case 'ListValue':
     return value.values.map(value => parseArgValue(value, variableValues))
   case 'ObjectValue':
-    return value.fields.map(value => parseArgValue(value, variableValues));
+    return value.fields.map(value => parseArgValue(value, variableValues))
   case 'ObjectField':
-    return {name:value.name.value,value:value.value.value};
+    return {name:value.name.value,value:value.value.value}
   default:
     return value.value
   }


### PR DESCRIPTION
I tried to pass an input object as an argument to orderBy, which resulted in undefined..

```
 My query: credits(orderBy: {field: "name", direction:ASC}) {...}
.....
  orderBy: args => {
                console.log(args.orderBy); //Undefined
            },
```
After correction worked!!, please rate. Sorry for bad english.

PS: Please add to "^1.2.1-beta.9..." 