### PR TITLE
Support for limit query

### DIFF
--- a/src/query-ast-to-sql-ast/index.js
+++ b/src/query-ast-to-sql-ast/index.js
@@ -165,6 +165,10 @@ function handleTable(sqlASTNode, queryASTNode, field, gqlType, namespace, grabMa
    * and collect the relevant info
    */
 
+  if (field.limit) {
+    sqlASTNode.limit = field.limit
+  }
+
   // are they doing a one-to-many sql join?
   if (field.sqlJoin) {
     sqlASTNode.sqlJoin = field.sqlJoin

--- a/src/stringifiers/dialects/mariadb.js
+++ b/src/stringifiers/dialects/mariadb.js
@@ -36,6 +36,10 @@ const dialect = module.exports = {
 
   quote,
 
+  limit(limit) {
+    return ` LIMIT ${limit} `
+  },
+
   compositeKey(parent, keys) {
     keys = keys.map(key => `${quote(parent)}.${quote(key)}`)
     return `CONCAT(${keys.join(', ')})`

--- a/src/stringifiers/dialects/mysql.js
+++ b/src/stringifiers/dialects/mysql.js
@@ -10,6 +10,10 @@ module.exports = {
 
   quote,
 
+  limit(limit) {
+    return ` LIMIT ${limit} `
+  },
+
   compositeKey(parent, keys) {
     keys = keys.map(key => `${quote(parent)}.${quote(key)}`)
     return `CONCAT(${keys.join(', ')})`

--- a/src/stringifiers/dialects/oracle.js
+++ b/src/stringifiers/dialects/oracle.js
@@ -73,6 +73,10 @@ const dialect = module.exports = {
     return `NULLIF(${recursiveConcat(keys)}, '')`
   },
 
+  limit(limit) {
+    return ` OFFSET 0 ROWS FETCH NEXT ${limit} ROWS ONLY `
+  },
+
   handlePaginationAtRoot: async function(parent, node, prefix, context, selections, tables, wheres, orders) {
     const pagingWhereConditions = []
     if (node.sortKey) {

--- a/src/stringifiers/dialects/pg.js
+++ b/src/stringifiers/dialects/pg.js
@@ -13,6 +13,10 @@ const dialect = module.exports = {
     return `"${str}"`
   },
 
+  limit(limit) {
+    return ` LIMIT ${limit} `
+  },
+
   compositeKey(parent, keys) {
     keys = keys.map(key => `"${parent}"."${key}"`)
     return `NULLIF(CONCAT(${keys.join(', ')}), '')`

--- a/src/stringifiers/dialects/sqlite3.js
+++ b/src/stringifiers/dialects/sqlite3.js
@@ -10,6 +10,10 @@ module.exports = {
 
   quote,
 
+  limit(limit) {
+    return ` LIMIT ${limit} `
+  },
+
   compositeKey(parent, keys) {
     keys = keys.map(key => `${quote(parent)}.${quote(key)}`)
     return keys.join(' || ')

--- a/test-api/schema-basic/Comment.js
+++ b/test-api/schema-basic/Comment.js
@@ -60,7 +60,8 @@ export default new GraphQLObjectType({
       sqlJoins: [
         (commentTable, likesTable) => `${commentTable}.${q('id', DB)} = ${likesTable}.${q('comment_id', DB)}`,
         (likesTable, userTable) => `${likesTable}.${q('account_id', DB)} = ${userTable}.${q('id', DB)}`
-      ]
+      ],
+      limit: 4
     },
     archived: {
       type: GraphQLBoolean

--- a/test/union.js
+++ b/test/union.js
@@ -65,14 +65,6 @@ test('it should a union type', async t => {
           authorId: 1,
           postId: 2,
           likers: []
-        },
-        {
-          __typename: 'Comment',
-          id: 8,
-          body: 'Somebody please help me with this library. It is so much work.',
-          authorId: 1,
-          postId: 2,
-          likers: []
         }
       ]
     }
@@ -130,14 +122,6 @@ test('it should an interface type', async t => {
           __typename: 'Comment',
           id: 6,
           body: 'Also, submit a PR if you have a feature you want to add.',
-          authorId: 1,
-          postId: 2,
-          likers: []
-        },
-        {
-          __typename: 'Comment',
-          id: 8,
-          body: 'Somebody please help me with this library. It is so much work.',
           authorId: 1,
           postId: 2,
           likers: []


### PR DESCRIPTION
Hi, I have added support for limit query, i.e., while creating a GraphQL type, you can specify limit of the returned items. We needed this feature for some purposes, e.g., returning only limited count of items.