### PR TITLE
Node 6.x incompatibility fix

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "presets": [ "node6", "stage-0" ]
+  "presets": [ "node6", "stage-0" ],
+  "plugins": [ "object-values-to-object-keys" ]
 }

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "ava": "^0.19.1",
     "babel-cli": "^6.14.0",
     "babel-eslint": "^7.0.0",
+    "babel-plugin-object-values-to-object-keys": "^1.0.2",
     "babel-preset-node6": "^11.0.0",
     "babel-preset-stage-0": "^6.5.0",
     "babel-watch": "^2.0.3-rc0",


### PR DESCRIPTION
This PR fixes incompatibility with node 6.x discussed in #144 by adding `babel-plugin-object-values-to-object-keys` to the build.