### PR TITLE
FIX: TypeError: Cannot read property 'length' of null.

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -56,6 +56,10 @@ export function cursorToObj(cursor) {
 
 // wrap in a pair of single quotes for the SQL if needed
 export function maybeQuote(value, dialectName) {
+  if (value == null) {
+    return 'NULL'
+  }
+
   if (typeof value === 'number') return value
   if (value && typeof value.toSQL === 'function') return value.toSQL()
 


### PR DESCRIPTION
This error occurs when you are requesting related table by sqlBatch and the foreign key in parent table is null. In this case method util.maybeQuote access property of value that is null (i.e., value.length) and fails.