### PR TITLE
Add TypeScript definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ Explore the schema, try out some queries, and see what the resulting SQL queries
 - [ ] Address this known bug [#126](https://github.com/stems/join-monster/issues/126).
 - [ ] Support custom `ORDER BY` expressions [#138](https://github.com/stems/join-monster/issues/138).
 - [ ] Support binding parameters [#169](https://github.com/stems/join-monster/issues/169).
-- [ ] Write static [Flow](https://flow.org/) types or TypeScript.
+- [ ] Write static [Flow](https://flow.org/) types.
 - [ ] Support "lookup tables" where a column might be an enum code to look up in another table.
 - [ ] Support "hyperjunctions" where many-to-many relations can join through multiple junction tables.
 - [ ] Cover more SQL dialects, like MSSQL and DB2.

--- a/package.json
+++ b/package.json
@@ -9,8 +9,9 @@
   "files": [
     "dist/"
   ],
+  "types": "dist/index.d.ts",
   "scripts": {
-    "build": "rm -rf dist && babel src --no-comments --out-dir dist",
+    "build": "rm -rf dist && babel src --no-comments --out-dir dist --copy-files --ignore README.md",
     "watch": "rm -rf dist && babel src --watch --source-maps true --out-dir dist",
     "test": "npm run lint && bin/test --no-oracle",
     "testsqlite3": "NODE_ENV=test ava test/*.js",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -59,11 +59,23 @@ declare module 'graphql/type/definition' {
   }
 }
 
+export interface GraphQLUnionTypeConfig<TSource, TContext> {
+  sqlTable?: string
+  uniqueKey?: string | string[]
+  alwaysFetch?: string
+}
+
+export interface GraphQLInterfaceTypeConfig<TSource, TContext> {
+  sqlTable?: string
+  uniqueKey?: string | string[]
+  alwaysFetch?: string
+}
+
 // JoinMonster lib interface
 
 interface DialectModule { name: string }
 
-type Dialect = 'pg' | 'oracle' | 'mariadb' | 'mysql' | 'sqlite'
+type Dialect = 'pg' | 'oracle' | 'mariadb' | 'mysql' | 'sqlite3'
 type JoinMonsterOptions = { minify?: boolean, dialect?: Dialect, dialectModule?: DialectModule }
 
 type Rows = any

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -6,39 +6,46 @@ import * as graphql from 'graphql'
 declare module 'graphql/type/definition' {
   type SqlJoin<TContext, TArgs> = (table1: string, table2: string, args: TArgs, context: TContext) => string
   type Where<TContext, TArgs> = (usersTable: string, args: TArgs, context: TContext) => string | void
-  type OrderBy = string | { [key: string]: 'ASC' | 'asc' | 'DESC' | 'desc' }
+  type Order = 'ASC' | 'asc' | 'DESC' | 'desc'
+  type OrderBy = string | { [key: string]: Order }
+  type ThunkWithArgsCtx<T, TContext, TArgs> = ((args: TArgs, context: TContext) => T) | T;
 
   export interface GraphQLObjectTypeConfig<TSource, TContext> {
     alwaysFetch?: string
-    sqlTable?: string
-    uniqueKey?: string
+    sqlTable?: ThunkWithArgsCtx<string, any, TContext>
+    uniqueKey?: string | string[]
   }
 
   export interface GraphQLFieldConfig<TSource, TContext, TArgs> {
     jmIgnoreAll?: boolean
     jmIgnoreTable?: boolean
     junction?: {
-      include?: {
+      include?: ThunkWithArgsCtx<{
         sqlColumn?: string
         sqlExpr?: string
         sqlDeps?: string | string[]
-      }
+      }, TContext, TArgs>
+      orderBy?: ThunkWithArgsCtx<OrderBy, TContext, TArgs>
+      sortKey?: ThunkWithArgsCtx<{
+        order: Order
+        key: string | string[]
+      }, TContext, TArgs>
       sqlBatch?: {
         thisKey: string
         parentKey: string
         sqlJoin: SqlJoin<TContext, TArgs>
       }
       sqlJoins?: [SqlJoin<TContext, TArgs>, SqlJoin<TContext, TArgs>]
-      sqlTable: string
-      uniqueKey?: string[]
+      sqlTable: ThunkWithArgsCtx<string, TContext, TArgs>
+      uniqueKey?: string | string[]
       where?: Where<TContext, TArgs>
     }
-    limit?: number
-    orderBy?: Thunk<OrderBy>
-    sortKey?: {
-      order: 'ASC' | 'asc' | 'DESC' | 'desc'
+    limit?: ThunkWithArgsCtx<number, any, TContext>
+    orderBy?: ThunkWithArgsCtx<OrderBy, TContext, TArgs>
+    sortKey?: ThunkWithArgsCtx<{
+      order: Order
       key: string | string[]
-    }
+    }, TContext, TArgs>
     sqlBatch?: {
       thisKey: string
       parentKey: string

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,69 @@
+
+import * as graphql from 'graphql'
+
+// Extend graphql objects and fields
+
+declare module 'graphql/type/definition' {
+  type SqlJoin<TContext, TArgs> = (table1: string, table2: string, args: TArgs, context: TContext) => string
+  type Where<TContext, TArgs> = (usersTable: string, args: TArgs, context: TContext) => string | void
+  type OrderBy = string | { [key: string]: 'ASC' | 'asc' | 'DESC' | 'desc' }
+
+  export interface GraphQLObjectTypeConfig<TSource, TContext> {
+    alwaysFetch?: string
+    sqlTable?: string
+    uniqueKey?: string
+  }
+
+  export interface GraphQLFieldConfig<TSource, TContext, TArgs> {
+    jmIgnoreAll?: boolean
+    jmIgnoreTable?: boolean
+    junction?: {
+      include?: {
+        sqlColumn?: string
+        sqlExpr?: string
+        sqlDeps?: string | string[]
+      }
+      sqlBatch?: {
+        thisKey: string
+        parentKey: string
+        sqlJoin: SqlJoin<TContext, TArgs>
+      }
+      sqlJoins?: [SqlJoin<TContext, TArgs>, SqlJoin<TContext, TArgs>]
+      sqlTable: string
+      uniqueKey?: string[]
+      where?: Where<TContext, TArgs>
+    }
+    limit?: number
+    orderBy?: Thunk<OrderBy>
+    sortKey?: {
+      order: 'ASC' | 'asc' | 'DESC' | 'desc'
+      key: string | string[]
+    }
+    sqlBatch?: {
+      thisKey: string
+      parentKey: string
+    }
+    sqlColumn?: string
+    sqlDeps?: string[]
+    sqlExpr?: (table: string, args: TArgs, context: TContext) => string
+    sqlJoin?: SqlJoin<TContext, TArgs>
+    sqlPaginate?: boolean
+    where?: Where<TContext, TArgs>
+  }
+}
+
+// JoinMonster lib interface
+
+interface DialectModule { name: string }
+
+type Dialect = 'pg' | 'oracle' | 'mariadb' | 'mysql' | 'sqlite'
+type JoinMonsterOptions = { minify?: boolean, dialect?: Dialect, dialectModule?: DialectModule }
+
+type Rows = any
+type DbCallCallback = (sql:string, done: (err?: any, rows?: Rows) => void) => void
+type DbCallPromise = (sql: string) => Promise<Rows>
+type DbCall = DbCallCallback | DbCallPromise
+
+declare function joinMonster(resolveInfo: any, context: any, dbCall: DbCallCallback | DbCallPromise, options?: JoinMonsterOptions) : Promise<any>
+
+export default joinMonster

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -4,8 +4,8 @@ import * as graphql from 'graphql'
 // Extend graphql objects and fields
 
 declare module 'graphql/type/definition' {
-  type SqlJoin<TContext, TArgs> = (table1: string, table2: string, args: TArgs, context: TContext) => string
-  type Where<TContext, TArgs> = (usersTable: string, args: TArgs, context: TContext) => string | void
+  type SqlJoin<TContext, TArgs> = (table1: string, table2: string, args: TArgs, context: TContext, sqlASTNode: any) => string
+  type Where<TContext, TArgs> = (usersTable: string, args: TArgs, context: TContext, sqlASTNode: any) => string | void
   type Order = 'ASC' | 'asc' | 'DESC' | 'desc'
   type OrderBy = string | { [key: string]: Order }
   type ThunkWithArgsCtx<T, TContext, TArgs> = ((args: TArgs, context: TContext) => T) | T;
@@ -52,7 +52,7 @@ declare module 'graphql/type/definition' {
     }
     sqlColumn?: string
     sqlDeps?: string[]
-    sqlExpr?: (table: string, args: TArgs, context: TContext) => string
+    sqlExpr?: (table: string, args: TArgs, context: TContext, sqlASTNode: any) => string
     sqlJoin?: SqlJoin<TContext, TArgs>
     sqlPaginate?: boolean
     where?: Where<TContext, TArgs>


### PR DESCRIPTION
Adds TypeScript information to join-monster. This solves #135.

The definitions are not complete, but most types are added. E. g. I could not find an interface for `DialectModule`, but I think TypeScript definitions are not required there, as a developer would anyways have to dive into the documentation and source code. I went through the documentation and tried to add as many types as possible. Most importantly the GraphQL type definitions are extended, so that join-monster can be used without encountering annoying messages.

Please review the definitions, but also keep in mind, that they do not have to be perfect by now and can be extended later by follow-up PRs.

Consider the following when merging:
* I modified the build job to copy non-js files except `README.md`s to make babel add the file to `dist` instead of adding a manual `cp`-command. This was done adding `--copy-files --ignore README.md`.
* I did **NOT** add a `peerDependency` on `@types/graphql`. This is clearly not optimal for TS-users, who have not installed `@types/graphql`, as it will cause an (maybe incomprehensible) error when compiling TS. If the dependency would be added, anyone using join-monster, even JS users, will download `@types/graphql` as well, which is currenty 376K. Third option would be to cancel this PR and create a `@types/join-monster`-package. This would add more noise to `package.json` and `package-lock.json` for TS-users and require an additional step to work with join-monster, which IMHO is not worth it for a 4K-file. This is why I added the definitions this way.