### PR TITLE
PG dialect - cast as type if necessary for paginated batch queries

### DIFF
--- a/src/stringifiers/dialects/pg.js
+++ b/src/stringifiers/dialects/pg.js
@@ -46,8 +46,11 @@ const dialect = module.exports = {
   },
 
   handleBatchedManyToManyPaginated: async function(parent, node, context, tables, batchScope, joinCondition) {
+    const thisKeyOperand = generateCastExpressionFromValueType(
+      `"${node.junction.as}"."${node.junction.sqlBatch.thisKey.name}"`, batchScope[0]
+    )
     const pagingWhereConditions = [
-      `${generateCastExpressionFromValueType(`"${node.junction.as}"."${node.junction.sqlBatch.thisKey.name}"`, batchScope[0])} = temp."${node.junction.sqlBatch.parentKey.name}"`
+      `${thisKeyOperand} = temp."${node.junction.sqlBatch.parentKey.name}"`
     ]
     if (node.junction.where) {
       pagingWhereConditions.push(
@@ -64,7 +67,7 @@ const dialect = module.exports = {
     tables.push(tempTable)
 
     const lateralJoinCondition =
-      `${generateCastExpressionFromValueType(`"${node.junction.as}"."${node.junction.sqlBatch.thisKey.name}"`, batchScope[0])} = temp."${node.junction.sqlBatch.parentKey.name}"`
+      `${thisKeyOperand} = temp."${node.junction.sqlBatch.parentKey.name}"`
 
     const lateralJoinOptions = { joinCondition: lateralJoinCondition, joinType: 'LEFT' }
     if (node.where || node.orderBy) {
@@ -159,8 +162,9 @@ const dialect = module.exports = {
   },
 
   handleBatchedOneToManyPaginated: async function(parent, node, context, tables, batchScope) {
+    const thisKeyOperand = generateCastExpressionFromValueType(`"${node.as}"."${node.sqlBatch.thisKey.name}"`, batchScope[0])
     const pagingWhereConditions = [
-      `${generateCastExpressionFromValueType(`"${node.as}"."${node.sqlBatch.thisKey.name}"`, batchScope[0])} = temp."${node.sqlBatch.parentKey.name}"`
+      `${thisKeyOperand} = temp."${node.sqlBatch.parentKey.name}"`
     ]
     if (node.where) {
       pagingWhereConditions.push(
@@ -169,7 +173,7 @@ const dialect = module.exports = {
     }
     const tempTable = `FROM (VALUES ${batchScope.map(val => `(${val})`)}) temp("${node.sqlBatch.parentKey.name}")`
     tables.push(tempTable)
-    const lateralJoinCondition = `${generateCastExpressionFromValueType(`"${node.as}"."${node.sqlBatch.thisKey.name}"`, batchScope[0])} = temp."${node.sqlBatch.parentKey.name}"`
+    const lateralJoinCondition = `${thisKeyOperand} = temp."${node.sqlBatch.parentKey.name}"`
     if (node.sortKey) {
       const { limit, order, whereCondition: whereAddendum } = interpretForKeysetPaging(node, dialect)
       pagingWhereConditions.push(whereAddendum)

--- a/src/stringifiers/dialects/pg.js
+++ b/src/stringifiers/dialects/pg.js
@@ -6,15 +6,6 @@ import {
   generateCastExpressionFromValueType
 } from '../shared'
 
-
-
-export function _getCastFromValueType(val) {
-  const casts = {
-    'string': '::TEXT',
-  }
-  return casts[typeof val] || ''
-}
-
 const dialect = module.exports = {
   name: 'pg',
 

--- a/src/stringifiers/shared.js
+++ b/src/stringifiers/shared.js
@@ -6,6 +6,20 @@ export function joinPrefix(prefix) {
   return prefix.slice(1).map(name => name + '__').join('')
 }
 
+
+
+export function generateCastExpressionFromValueType(key, val) {
+  const castTypes = {
+    'string': 'TEXT',
+  }
+  const type = castTypes[typeof val] || null;
+
+  if (type) {
+    return `CAST(${key} AS ${type})`; 
+  }
+  return key;
+}
+
 function doubleQuote(str) {
   return `"${str}"`
 }

--- a/src/stringifiers/shared.js
+++ b/src/stringifiers/shared.js
@@ -7,17 +7,16 @@ export function joinPrefix(prefix) {
 }
 
 
-
 export function generateCastExpressionFromValueType(key, val) {
   const castTypes = {
-    'string': 'TEXT',
+    string: 'TEXT'
   }
-  const type = castTypes[typeof val] || null;
+  const type = castTypes[typeof val] || null
 
   if (type) {
-    return `CAST(${key} AS ${type})`; 
+    return `CAST(${key} AS ${type})`
   }
-  return key;
+  return key
 }
 
 function doubleQuote(str) {


### PR DESCRIPTION
Adds `generateCastExpressionFromValueType` function which creates a CAST sql expression based on type of passed value. This is used to ensure the left operand matches the type of the right in paginated batch queries.

Resolves #316 for `pg` dialect.