### PR TITLE
Support computed columns for sorting

### DIFF
--- a/src/stringifiers/dialects/mariadb.js
+++ b/src/stringifiers/dialects/mariadb.js
@@ -19,20 +19,22 @@ ${unions.join('\nUNION\n')}
 ) AS ${quote(as)}`
 }
 
-function paginatedSelect(table, as, whereConditions, order, limit, offset, opts = {}) {
+function paginatedSelect(expressions, table, as, whereConditions, order, limit, offset, opts = {}) {
   const { extraJoin, withTotal } = opts
   as = quote(as)
+  const selections = [ `${as}.*`, ...expressions.map(expr => `${expr.expr} AS ${expr.as}`) ].join(',\n  ')
+  order = orderColumnsToString(order.columns, quote, order.table)
   return `\
-  (SELECT ${as}.*${withTotal ? ', count(*) OVER () AS `$total`' : ''}
+  (SELECT ${selections}${withTotal ? `,\n  count(*) OVER () AS ${quote('$total')}` : ''}
   FROM ${table} ${as}
   ${extraJoin ? `LEFT JOIN ${extraJoin.name} ${quote(extraJoin.as)}
     ON ${extraJoin.condition}` : ''}
   WHERE ${whereConditions}
-  ORDER BY ${orderColumnsToString(order.columns, quote, order.table)}
+  ORDER BY ${order}
   LIMIT ${limit}${offset ? ' OFFSET ' + offset : ''})`
 }
 
-const dialect = module.exports = {
+const dialect = (module.exports = {
   ...require('./mixins/pagination-not-supported'),
 
   name: 'mariadb',
@@ -44,7 +46,7 @@ const dialect = module.exports = {
     return `CONCAT(${keys.join(', ')})`
   },
 
-  handlePaginationAtRoot: async function(parent, node, context, tables) {
+  handlePaginationAtRoot: async function(parent, node, context, expressions, tables) {
     const pagingWhereConditions = []
     if (node.sortKey) {
       const { limit, order, whereCondition: whereAddendum } = interpretForKeysetPaging(node, dialect)
@@ -54,9 +56,7 @@ const dialect = module.exports = {
           await node.where(`${quote(node.as)}`, node.args || {}, context, node)
         )
       }
-      tables.push(
-        keysetPagingSelect(node.name, pagingWhereConditions, order, limit, node.as, { q: quote })
-      )
+      tables.push(keysetPagingSelect(expressions, node.name, pagingWhereConditions, order, limit, node.as, { q: quote }))
     } else if (node.orderBy) {
       const { limit, offset, order } = interpretForOffsetPaging(node, dialect)
       if (node.where) {
@@ -65,12 +65,12 @@ const dialect = module.exports = {
         )
       }
       tables.push(
-        offsetPagingSelect(node.name, pagingWhereConditions, order, limit, offset, node.as, { q: quote })
+        offsetPagingSelect(expressions, node.name, pagingWhereConditions, order, limit, offset, node.as, { q: quote })
       )
     }
   },
 
-  handleBatchedOneToManyPaginated: async function(parent, node, context, tables, batchScope) {
+  handleBatchedOneToManyPaginated: async function(parent, node, context, expressions, tables, batchScope) {
     const pagingWhereConditions = []
     if (node.where) {
       pagingWhereConditions.push(
@@ -83,7 +83,7 @@ const dialect = module.exports = {
       const unions = batchScope.map(val => {
         let whereConditions = [ ...pagingWhereConditions, `${quote(node.as)}.${quote(node.sqlBatch.thisKey.name)} = ${val}` ]
         whereConditions = filter(whereConditions).join(' AND ') || '1'
-        return paginatedSelect(node.name, node.as, whereConditions, order, limit, null)
+        return paginatedSelect(expressions, node.name, node.as, whereConditions, order, limit, null)
       })
       tables.push(joinUnions(unions, node.as))
     } else if (node.orderBy) {
@@ -91,13 +91,13 @@ const dialect = module.exports = {
       const unions = batchScope.map(val => {
         let whereConditions = [ ...pagingWhereConditions, `${quote(node.as)}.${quote(node.sqlBatch.thisKey.name)} = ${val}` ]
         whereConditions = filter(whereConditions).join(' AND ') || '1'
-        return paginatedSelect(node.name, node.as, whereConditions, order, limit, offset, { withTotal: true })
+        return paginatedSelect(expressions, node.name, node.as, whereConditions, order, limit, offset, { withTotal: true })
       })
       tables.push(joinUnions(unions, node.as))
     }
   },
 
-  handleBatchedManyToManyPaginated: async function(parent, node, context, tables, batchScope, joinCondition) {
+  handleBatchedManyToManyPaginated: async function(parent, node, context, expressions, tables, batchScope, joinCondition) {
     const pagingWhereConditions = []
     if (node.junction.where) {
       pagingWhereConditions.push(
@@ -126,7 +126,9 @@ const dialect = module.exports = {
           `${quote(node.junction.as)}.${quote(node.junction.sqlBatch.thisKey.name)} = ${val}`
         ]
         whereConditions = filter(whereConditions).join(' AND ') || '1'
-        return paginatedSelect(node.junction.sqlTable, node.junction.as, whereConditions, order, limit, null, { extraJoin })
+        return paginatedSelect(expressions, node.junction.sqlTable, node.junction.as, whereConditions, order, limit, null, {
+          extraJoin
+        })
       })
       tables.push(joinUnions(unions, node.junction.as))
     } else if (node.orderBy || node.junction.orderBy) {
@@ -137,13 +139,22 @@ const dialect = module.exports = {
           `${quote(node.junction.as)}.${quote(node.junction.sqlBatch.thisKey.name)} = ${val}`
         ]
         whereConditions = filter(whereConditions).join(' AND ') || '1'
-        return paginatedSelect(node.junction.sqlTable, node.junction.as, whereConditions, order, limit, offset, {
-          withTotal: true,
-          extraJoin
-        })
+        return paginatedSelect(
+          expressions,
+          node.junction.sqlTable,
+          node.junction.as,
+          whereConditions,
+          order,
+          limit,
+          offset,
+          {
+            withTotal: true,
+            extraJoin
+          }
+        )
       })
       tables.push(joinUnions(unions, node.junction.as))
     }
     tables.push(`LEFT JOIN ${node.name} AS ${quote(node.as)} ON ${joinCondition}`)
   }
-}
+})

--- a/src/stringifiers/dialects/pg.js
+++ b/src/stringifiers/dialects/pg.js
@@ -27,7 +27,7 @@ const dialect = module.exports = {
 
     // which type of pagination are they using?
     if (node.sortKey) {
-      const { limit, order, whereCondition: whereAddendum } = interpretForKeysetPaging(node, dialect)
+      const { limit, order, whereCondition: whereAddendum } = interpretForKeysetPaging(node, dialect, expressions)
       pagingWhereConditions.push(whereAddendum)
       tables.push(
         keysetPagingSelect(expressions, node.name, pagingWhereConditions, order, limit, node.as, {
@@ -36,7 +36,7 @@ const dialect = module.exports = {
         })
       )
     } else if (node.orderBy) {
-      const { limit, offset, order } = interpretForOffsetPaging(node, dialect)
+      const { limit, offset, order } = interpretForOffsetPaging(node, dialect, expressions)
       tables.push(
         offsetPagingSelect(expressions, node.name, pagingWhereConditions, order, limit, offset, node.as, {
           joinCondition,
@@ -76,7 +76,7 @@ const dialect = module.exports = {
       }
     }
     if (node.sortKey || node.junction.sortKey) {
-      const { limit, order, whereCondition: whereAddendum } = interpretForKeysetPaging(node, dialect)
+      const { limit, order, whereCondition: whereAddendum } = interpretForKeysetPaging(node, dialect, expressions)
       pagingWhereConditions.push(whereAddendum)
       tables.push(
         keysetPagingSelect(
@@ -90,7 +90,7 @@ const dialect = module.exports = {
         )
       )
     } else if (node.orderBy || node.junction.orderBy) {
-      const { limit, offset, order } = interpretForOffsetPaging(node, dialect)
+      const { limit, offset, order } = interpretForOffsetPaging(node, dialect, expressions)
       tables.push(
         offsetPagingSelect(
           expressions,
@@ -139,7 +139,7 @@ const dialect = module.exports = {
       }
     }
     if (node.sortKey || node.junction.sortKey) {
-      const { limit, order, whereCondition: whereAddendum } = interpretForKeysetPaging(node, dialect)
+      const { limit, order, whereCondition: whereAddendum } = interpretForKeysetPaging(node, dialect, expressions)
       pagingWhereConditions.push(whereAddendum)
       tables.push(
         keysetPagingSelect(
@@ -153,7 +153,7 @@ const dialect = module.exports = {
         )
       )
     } else if (node.orderBy || node.junction.orderBy) {
-      const { limit, offset, order } = interpretForOffsetPaging(node, dialect)
+      const { limit, offset, order } = interpretForOffsetPaging(node, dialect, expressions)
       tables.push(
         offsetPagingSelect(
           expressions,
@@ -172,7 +172,7 @@ const dialect = module.exports = {
   handlePaginationAtRoot: async function(parent, node, context, expressions, tables) {
     const pagingWhereConditions = []
     if (node.sortKey) {
-      const { limit, order, whereCondition: whereAddendum } = interpretForKeysetPaging(node, dialect)
+      const { limit, order, whereCondition: whereAddendum } = interpretForKeysetPaging(node, dialect, expressions)
       pagingWhereConditions.push(whereAddendum)
       if (node.where) {
         pagingWhereConditions.push(
@@ -181,7 +181,7 @@ const dialect = module.exports = {
       }
       tables.push(keysetPagingSelect(expressions, node.name, pagingWhereConditions, order, limit, node.as))
     } else if (node.orderBy) {
-      const { limit, offset, order } = interpretForOffsetPaging(node, dialect)
+      const { limit, offset, order } = interpretForOffsetPaging(node, dialect, expressions)
       if (node.where) {
         pagingWhereConditions.push(
           await node.where(`"${node.as}"`, node.args || {}, context, node)
@@ -202,7 +202,7 @@ const dialect = module.exports = {
     tables.push(tempTable)
     const lateralJoinCondition = `"${node.as}"."${node.sqlBatch.thisKey.name}" = temp."${node.sqlBatch.parentKey.name}"`
     if (node.sortKey) {
-      const { limit, order, whereCondition: whereAddendum } = interpretForKeysetPaging(node, dialect)
+      const { limit, order, whereCondition: whereAddendum } = interpretForKeysetPaging(node, dialect, expressions)
       pagingWhereConditions.push(whereAddendum)
       tables.push(
         keysetPagingSelect(expressions, node.name, pagingWhereConditions, order, limit, node.as, {
@@ -210,7 +210,7 @@ const dialect = module.exports = {
         })
       )
     } else if (node.orderBy) {
-      const { limit, offset, order } = interpretForOffsetPaging(node, dialect)
+      const { limit, offset, order } = interpretForOffsetPaging(node, dialect, expressions)
       tables.push(
         offsetPagingSelect(expressions, node.name, pagingWhereConditions, order, limit, offset, node.as, {
           joinCondition: lateralJoinCondition

--- a/src/stringifiers/dispatcher.js
+++ b/src/stringifiers/dispatcher.js
@@ -18,24 +18,25 @@ export default async function stringifySqlAST(topNode, context, options) {
 
   // recursively figure out all the selections, joins, and where conditions that we need
   let { selections, tables, wheres, orders } = await _stringifySqlAST(
-    null, topNode, [],
-    context, [], [],
-    [], [], options.batchScope,
+    null,
+    topNode,
+    [], // prefix
+    context,
+    // Use a set for sleections to prevent duplicate fields.
+    // GraphQL does not prevent queries with duplicate fields
+    new Set(),
+    [], // tables
+    [], // wheres
+    [], // orders
+    options.batchScope,
     dialect
   )
 
-  // make sure these are unique by converting to a set and then back to an array
-  // e.g. we want to get rid of things like `SELECT user.id as id, user.id as id, ...`
-  // GraphQL does not prevent queries with duplicate fields
-  selections = [ ...new Set(selections) ]
-
   // bail out if they made no selections
-  if (!selections.length) return ''
+  if (!selections.size) return ''
 
   // put together the SQL query
-  let sql = 'SELECT\n  ' +
-    selections.join(',\n  ') + '\n' +
-    tables.join('\n')
+  let sql = 'SELECT\n  ' + [ ...selections ].join(',\n  ') + '\n' + tables.join('\n')
 
   wheres = filter(wheres)
   if (wheres.length) {
@@ -49,75 +50,112 @@ export default async function stringifySqlAST(topNode, context, options) {
   return sql
 }
 
+async function _stringifySqlASTExpressions(parent, node, prefix, context, expressions, dialect) {
+  const { quote: q } = dialect
+  const parentTable = node.fromOtherTable || (parent && parent.as)
+  if (node.type === 'expression') {
+    const table = `${q(parentTable)}`
+    const expr = await node.sqlExpr(table, node.args || {}, context, node)
+    expressions.push({ table: table, expr: `${expr}`, as: `${q(joinPrefix(prefix) + node.as)}` })
+  }
+}
+
 async function _stringifySqlAST(parent, node, prefix, context, selections, tables, wheres, orders, batchScope, dialect) {
   const { quote: q } = dialect
   const parentTable = node.fromOtherTable || (parent && parent.as)
+  let expressions
   switch (node.type) {
   case 'table':
-    await handleTable(parent, node, prefix, context, selections, tables, wheres, orders, batchScope, dialect)
-
     // recurse thru nodes
+    expressions = []
+    if (thisIsNotTheEndOfThisBatch(node, parent)) {
+      for (let child of node.children) {
+        await _stringifySqlASTExpressions(node, child, [ ...prefix, node.as ], context, expressions, dialect)
+      }
+    }
+
+    await handleTable(parent, node, prefix, context, selections, expressions, tables, wheres, orders, batchScope, dialect)
+
     if (thisIsNotTheEndOfThisBatch(node, parent)) {
       for (let child of node.children) {
         await _stringifySqlAST(
-          node, child, [ ...prefix, node.as ],
-          context, selections, tables,
-          wheres, orders, null,
+          node,
+          child,
+          [ ...prefix, node.as ],
+          context,
+          selections,
+          tables,
+          wheres,
+          orders,
+          null,
           dialect
         )
       }
     }
-
     break
   case 'union':
-    await handleTable(parent, node, prefix, context, selections, tables, wheres, orders, batchScope, dialect)
-
     // recurse thru nodes
+    expressions = []
+    if (thisIsNotTheEndOfThisBatch(node, parent)) {
+      for (let typeName in node.typedChildren) {
+        for (let child of node.typedChildren[typeName]) {
+          await _stringifySqlASTExpressions(node, child, [ ...prefix, node.as ], context, expressions, dialect)
+        }
+      }
+      for (let child of node.children) {
+        await _stringifySqlASTExpressions(node, child, [ ...prefix, node.as ], context, expressions, dialect)
+      }
+    }
+
+    await handleTable(parent, node, prefix, context, selections, expressions, tables, wheres, orders, batchScope, dialect)
+
     if (thisIsNotTheEndOfThisBatch(node, parent)) {
       for (let typeName in node.typedChildren) {
         for (let child of node.typedChildren[typeName]) {
           await _stringifySqlAST(
-            node, child, [ ...prefix, node.as ],
-            context, selections, tables,
-            wheres, orders, null,
+            node,
+            child,
+            [ ...prefix, node.as ],
+            context,
+            selections,
+            tables,
+            wheres,
+            orders,
+            null,
             dialect
           )
         }
       }
       for (let child of node.children) {
         await _stringifySqlAST(
-          node, child, [ ...prefix, node.as ],
-          context, selections, tables,
-          wheres, orders, null,
+          node,
+          child,
+          [ ...prefix, node.as ],
+          context,
+          selections,
+          tables,
+          wheres,
+          orders,
+          null,
           dialect
         )
       }
     }
-
     break
   case 'column':
-    selections.push(
-      `${q(parentTable)}.${q(node.name)} AS ${q(joinPrefix(prefix) + node.as)}`
-    )
+    selections.add(`${q(parentTable)}.${q(node.name)} AS ${q(joinPrefix(prefix) + node.as)}`)
     break
   case 'columnDeps':
     // grab the dependant columns
     for (let name in node.names) {
-      selections.push(
-        `${q(parentTable)}.${q(name)} AS ${q(joinPrefix(prefix) + node.names[name])}`
-      )
+      selections.add(`${q(parentTable)}.${q(name)} AS ${q(joinPrefix(prefix) + node.names[name])}`)
     }
     break
   case 'composite':
-    selections.push(
-      `${dialect.compositeKey(parentTable, node.name)} AS ${q(joinPrefix(prefix) + node.as)}`
-    )
+    selections.add(`${dialect.compositeKey(parentTable, node.name)} AS ${q(joinPrefix(prefix) + node.as)}`)
     break
   case 'expression':
-    const expr = await node.sqlExpr(`${q(parentTable)}`, node.args || {}, context, node)
-    selections.push(
-      `${expr} AS ${q(joinPrefix(prefix) + node.as)}`
-    )
+    // Handled in _stringifySqlASTExpressions()
     break
   case 'noop':
     // we hit this with fields that don't need anything from SQL, they resolve independently
@@ -128,7 +166,20 @@ async function _stringifySqlAST(parent, node, prefix, context, selections, table
   return { selections, tables, wheres, orders }
 }
 
-async function handleTable(parent, node, prefix, context, selections, tables, wheres, orders, batchScope, dialect) {
+async function handleTable(
+  parent,
+  node,
+  prefix,
+  context,
+  selections,
+  expressions,
+  tables,
+  wheres,
+  orders,
+  batchScope,
+  dialect
+) {
+  let usedNestedQuery = false
   const { quote: q } = dialect
   // generate the "where" condition, if applicable
   if (whereConditionIsntSupposedToGoInsideSubqueryOrOnNextBatch(node, parent)) {
@@ -173,13 +224,14 @@ async function handleTable(parent, node, prefix, context, selections, tables, wh
 
     // do we need to paginate? if so this will be a lateral join
     if (node.paginate) {
-      await dialect.handleJoinedOneToManyPaginated(parent, node, context, tables, joinCondition)
-
-    // limit has a highly similar approach to paginating
+      await dialect.handleJoinedOneToManyPaginated(parent, node, context, expressions, tables, joinCondition)
+      usedNestedQuery = true
+      // limit has a highly similar approach to paginating
     } else if (node.limit) {
       node.args.first = node.limit
-      await dialect.handleJoinedOneToManyPaginated(parent, node, context, tables, joinCondition)
-    // otherwite, just a regular left join on the table
+      await dialect.handleJoinedOneToManyPaginated(parent, node, context, expressions, tables, joinCondition)
+      usedNestedQuery = true
+      // otherwite, just a regular left join on the table
     } else {
       tables.push(
         `LEFT JOIN ${node.name} ${q(node.as)} ON ${joinCondition}`
@@ -189,18 +241,22 @@ async function handleTable(parent, node, prefix, context, selections, tables, wh
   // many-to-many using batching
   } else if (idx(node, _ => _.junction.sqlBatch)) {
     if (parent) {
-      selections.push(
-        `${q(parent.as)}.${q(node.junction.sqlBatch.parentKey.name)} AS ${q(joinPrefix(prefix) + node.junction.sqlBatch.parentKey.as)}`
+      selections.add(
+        `${q(parent.as)}.${q(node.junction.sqlBatch.parentKey.name)} AS ${q(
+          joinPrefix(prefix) + node.junction.sqlBatch.parentKey.as
+        )}`
       )
     } else {
       const joinCondition = await node.junction.sqlBatch.sqlJoin(
         `${q(node.junction.as)}`, q(node.as), node.args || {}, context, node
       )
       if (node.paginate) {
-        await dialect.handleBatchedManyToManyPaginated(parent, node, context, tables, batchScope, joinCondition)
+        await dialect.handleBatchedManyToManyPaginated(parent, node, context, expressions, tables, batchScope, joinCondition)
+        usedNestedQuery = true
       } else if (node.limit) {
         node.args.first = node.limit
-        await dialect.handleBatchedManyToManyPaginated(parent, node, context, tables, batchScope, joinCondition)
+        await dialect.handleBatchedManyToManyPaginated(parent, node, context, expressions, tables, batchScope, joinCondition)
+        usedNestedQuery = true
       } else {
         tables.push(
           `FROM ${node.junction.sqlTable} ${q(node.junction.as)}`,
@@ -219,14 +275,30 @@ async function handleTable(parent, node, prefix, context, selections, tables, wh
       .sqlJoins[1](`${q(node.junction.as)}`, q(node.as), node.args || {}, context, node)
 
     if (node.paginate) {
-      await dialect.handleJoinedManyToManyPaginated(parent, node, context, tables, joinCondition1, joinCondition2)
+      await dialect.handleJoinedManyToManyPaginated(
+        parent,
+        node,
+        context,
+        expressions,
+        tables,
+        joinCondition1,
+        joinCondition2
+      )
+      usedNestedQuery = true
     } else if (node.limit) {
       node.args.first = node.limit
-      await dialect.handleJoinedManyToManyPaginated(parent, node, context, tables, joinCondition1, joinCondition2)
-    } else {
-      tables.push(
-        `LEFT JOIN ${node.junction.sqlTable} ${q(node.junction.as)} ON ${joinCondition1}`
+      await dialect.handleJoinedManyToManyPaginated(
+        parent,
+        node,
+        context,
+        expressions,
+        tables,
+        joinCondition1,
+        joinCondition2
       )
+      usedNestedQuery = true
+    } else {
+      tables.push(`LEFT JOIN ${node.junction.sqlTable} ${q(node.junction.as)} ON ${joinCondition1}`)
     }
     tables.push(
       `LEFT JOIN ${node.name} ${q(node.as)} ON ${joinCondition2}`
@@ -235,14 +307,16 @@ async function handleTable(parent, node, prefix, context, selections, tables, wh
   // one-to-many with batching
   } else if (node.sqlBatch) {
     if (parent) {
-      selections.push(
+      selections.add(
         `${q(parent.as)}.${q(node.sqlBatch.parentKey.name)} AS ${q(joinPrefix(prefix) + node.sqlBatch.parentKey.as)}`
       )
     } else if (node.paginate) {
-      await dialect.handleBatchedOneToManyPaginated(parent, node, context, tables, batchScope)
+      await dialect.handleBatchedOneToManyPaginated(parent, node, context, expressions, tables, batchScope)
+      usedNestedQuery = true
     } else if (node.limit) {
       node.args.first = node.limit
-      await dialect.handleBatchedOneToManyPaginated(parent, node, context, tables, batchScope)
+      await dialect.handleBatchedOneToManyPaginated(parent, node, context, expressions, tables, batchScope)
+      usedNestedQuery = true
       // otherwite, just a regular left join on the table
     } else {
       tables.push(
@@ -252,15 +326,22 @@ async function handleTable(parent, node, prefix, context, selections, tables, wh
     }
   // otherwise, we aren't joining, so we are at the "root", and this is the start of the FROM clause
   } else if (node.paginate) {
-    await dialect.handlePaginationAtRoot(parent, node, context, tables)
+    await dialect.handlePaginationAtRoot(parent, node, context, expressions, tables)
+    usedNestedQuery = true
   } else if (node.limit) {
     node.args.first = node.limit
-    await dialect.handlePaginationAtRoot(parent, node, context, tables)
+    await dialect.handlePaginationAtRoot(parent, node, context, expressions, tables)
+    usedNestedQuery = true
   } else {
     assert(!parent, `Object type for "${node.fieldName}" table must have a "sqlJoin" or "sqlBatch"`)
-    tables.push(
-      `FROM ${node.name} ${q(node.as)}`
-    )
+    tables.push(`FROM ${node.name} ${q(node.as)}`)
+  }
+
+  // Add any unused expressions to the selections
+  if (usedNestedQuery) {
+    expressions.forEach(expr => selections.add(`${expr.table}.${expr.as} AS ${expr.as}`))
+  } else {
+    expressions.forEach(expr => selections.add(`${expr.expr} AS ${expr.as}`))
   }
 }
 
@@ -289,4 +370,5 @@ function sortKeyToOrderColumns(sortKey, args) {
   }
   return orderColumns
 }
+
 

--- a/test/columns.js
+++ b/test/columns.js
@@ -356,11 +356,11 @@ test('it should handle raw SQL expressions', async t => {
   const query = `{
     user(id: 2) {
       fullName
-      capitalizedLastName
+      transformedLastName
     }
   }`
   const { data, errors } = await run(query)
   errCheck(t, errors)
-  t.is(data.user.fullName.split(' ')[1].toUpperCase(), data.user.capitalizedLastName)
+  t.is(data.user.fullName.split(' ')[1].toUpperCase(), data.user.transformedLastName)
 })
 

--- a/test/order.js
+++ b/test/order.js
@@ -69,7 +69,7 @@ test('it should handle order on many-to-many', async t => {
   t.deepEqual(expect, data)
 })
 
-test('it sould handle order on many-to-many', async t => {
+test('it should handle order on many-to-many reverse', async t => {
   const query = `{
     user(id: 3) {
       fullName
@@ -99,3 +99,147 @@ test('it sould handle order on many-to-many', async t => {
   t.deepEqual(expect, data)
 })
 
+test('it should handle computed column order on root', async t => {
+  const query = `{
+    users(order: [ transformedLastName ]) {
+      id, transformedLastName
+    }
+  }`
+  const { data, errors } = await run(query)
+  errCheck(t, errors)
+  const expect = [
+    {
+      id: 3,
+      transformedLastName: 'BAR'
+    },
+    {
+      id: 1,
+      transformedLastName: 'CARLSON'
+    },
+    {
+      id: 2,
+      transformedLastName: 'ELDER'
+    }
+  ]
+  t.deepEqual(expect, data.users)
+})
+
+test('it should handle computed column order without requesting column', async t => {
+  const query = `{
+    users(order: [ transformedLastName ]) {
+      id
+    }
+  }`
+  const { data, errors } = await run(query)
+  errCheck(t, errors)
+  const expect = [
+    {
+      id: 3
+    },
+    {
+      id: 1
+    },
+    {
+      id: 2
+    }
+  ]
+  t.deepEqual(expect, data.users)
+})
+
+test('it should handle computed column order with arguments', async t => {
+  const query = `{
+    users(order: [ transformedLastName ]) {
+      id
+      transformedLastName(lowercase:true)
+    }
+  }`
+  const { data, errors } = await run(query)
+  errCheck(t, errors)
+  const expect = [
+    {
+      id: 3,
+      transformedLastName: 'bar'
+    },
+    {
+      id: 1,
+      transformedLastName: 'carlson'
+    },
+    {
+      id: 2,
+      transformedLastName: 'elder'
+    }
+  ]
+  t.deepEqual(expect, data.users)
+})
+
+test('it should handle computed column order on nested field', async t => {
+  const query = `{
+    user(id: 2) {
+      posts(order: [ numComments ]) {
+        id
+        numComments
+      }
+    }
+  }`
+  const { data, errors } = await run(query)
+  errCheck(t, errors)
+  const expect = [
+    {
+      id: 1,
+      numComments: 3
+    },
+    {
+      id: 3,
+      numComments: 1
+    }
+  ]
+  t.deepEqual(expect, data.user.posts)
+})
+
+test('it should handle computed column order on many-to-many', async t => {
+  const query = `{
+    user(id: 3) {
+      following(order: [ transformedLastName ]) {
+        id
+        transformedLastName
+      }
+    }
+  }`
+  const { data, errors } = await run(query)
+  errCheck(t, errors)
+  const expect = [
+    {
+      id: 1,
+      transformedLastName: 'CARLSON'
+    },
+    {
+      id: 2,
+      transformedLastName: 'ELDER'
+    }
+  ]
+  t.deepEqual(expect, data.user.following)
+})
+
+test('it should handle computed column order on many-to-many', async t => {
+  const query = `{
+    user(id: 3) {
+      following(order: [ transformedLastName ]) {
+        id
+        transformedLastName
+      }
+    }
+  }`
+  const { data, errors } = await run(query)
+  errCheck(t, errors)
+  const expect = [
+    {
+      id: 1,
+      transformedLastName: 'CARLSON'
+    },
+    {
+      id: 2,
+      transformedLastName: 'ELDER'
+    }
+  ]
+  t.deepEqual(expect, data.user.following)
+})

--- a/test/pagination/offset-paging.js
+++ b/test/pagination/offset-paging.js
@@ -686,6 +686,158 @@ test('should handle order columns on the junction table', async t => {
   t.deepEqual(expect, data)
 })
 
+test('should handle computed column order on root', async t => {
+  const query = `{
+    users(first: 3, order: [ capitalizedLastName ]) {
+      edges {
+        node { id, capitalizedLastName }
+      }
+    }
+  }`
+  const { data, errors } = await run(query)
+  errCheck(t, errors)
+  const expect = [
+    {
+      node: {
+        id: toGlobalId('User', 3),
+        capitalizedLastName: 'ABERNATHY'
+      }
+    },
+    {
+      node: {
+        id: toGlobalId('User', 4),
+        capitalizedLastName: 'BOGISICH'
+      }
+    },
+    {
+      node: {
+        id: toGlobalId('User', 6),
+        capitalizedLastName: 'CARLSON'
+      }
+    }
+  ]
+  t.deepEqual(expect, data.users.edges)
+})
+
+test('should handle computed column order without requesting column', async t => {
+  const query = `{
+    users(first: 3, order: [ capitalizedLastName ]) {
+      edges {
+        node { id, fullName }
+      }
+    }
+  }`
+  const { data, errors } = await run(query)
+  errCheck(t, errors)
+  const expect = {
+    users: {
+      edges: [
+        {
+          node: {
+            id: toGlobalId('User', 3),
+            fullName: 'Coleman Abernathy'
+          }
+        },
+        {
+          node: {
+            id: toGlobalId('User', 4),
+            fullName: 'Lulu Bogisich'
+          }
+        },
+        {
+          node: {
+            id: toGlobalId('User', 6),
+            fullName: 'Andrew Carlson'
+          }
+        }
+      ]
+    }
+  }
+  t.deepEqual(expect, data)
+})
+
+test('should handle computed column order on nested field', async t => {
+  const query = `{
+    user(id: 1) {
+      posts(first: 3, order: [ numComments, id ]) {
+        edges {
+          node { id, body, numComments }
+        }
+      }
+    }
+  }`
+  const { data, errors } = await run(query)
+  errCheck(t, errors)
+  const expect = [
+    {
+      node: {
+        id: toGlobalId('Post', 47),
+        body: [
+          'Dolores fugit qui eaque repellendus perspiciatis.',
+          'Sequi est eligendi beatae at. Pariatur ut placeat exercitationem facere quidem omnis.'
+        ].join(' '),
+        numComments: 10
+      }
+    },
+    {
+      node: {
+        id: toGlobalId('Post', 38),
+        body: [
+          'Quas omnis dignissimos eveniet non minus in voluptas.',
+          'Aliquam porro non nihil impedit officia ut.'
+        ].join(' '),
+        numComments: 7
+      }
+    },
+    {
+      node: {
+        id: toGlobalId('Post', 28),
+        body: 'Eum iure laudantium officia doloremque et ut fugit ut. Magni eveniet ipsa.',
+        numComments: 7
+      }
+    }
+  ]
+  t.deepEqual(expect, data.user.posts.edges)
+})
+
+test('should handle computed column order on many to many', async t => {
+  const query = `{
+    user(id: 3) {
+      following(order: [ capitalizedLastName ]) {
+        edges {
+          node {
+            id
+            capitalizedLastName
+          }
+        }
+      }
+    }
+  }`
+  const { data, errors } = await run(query)
+  errCheck(t, errors)
+  const expect = [
+    {
+      node: {
+        id: toGlobalId('User', 3),
+        capitalizedLastName: 'ABERNATHY'
+      }
+    },
+    {
+      node: {
+        id: toGlobalId('User', 4),
+        capitalizedLastName: 'BOGISICH'
+      }
+    },
+    {
+      node: {
+        id: toGlobalId('User', 2),
+        capitalizedLastName: 'HYATT'
+      }
+    }
+  ]
+  t.deepEqual(expect, data.user.following.edges)
+})
+
 test('should handle an interface type', async t => {
   const query = `{
     user(id: 1) {


### PR DESCRIPTION
Adds support for sorting using computed columns
- Create SqlAST expression nodes for computed columns listed in orderBy or sortKey so that they get requested even if they aren't in the field selection
- Move select statements of computed columns into nested queries if there is a nested query
- Drop the table prefix when referencing the computed column in order statement in the first reference