### PR TITLE
fixed bug preventing context from being passed to getNode

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -148,7 +148,7 @@ async function getNode(typeName, resolveInfo, context, condition, dbCall, option
   const sqlAST = {}
   const fieldNodes = resolveInfo.fieldNodes || resolveInfo.fieldASTs
   // uses the same underlying function as the main `joinMonster`
-  queryAST.populateASTNode.call(resolveInfo, fieldNodes[0], fakeParentNode, sqlAST, namespace, 0, options)
+  queryAST.populateASTNode.call(resolveInfo, fieldNodes[0], fakeParentNode, sqlAST, namespace, 0, options, context)
   queryAST.pruneDuplicateSqlDeps(sqlAST, namespace)
   const { sql, shapeDefinition } = await compileSqlAST(sqlAST, context, options)
   const data = arrToConnection(await handleUserDbCall(dbCall, sql, sqlAST, shapeDefinition), sqlAST)

--- a/test-api/data/fetch.js
+++ b/test-api/data/fetch.js
@@ -1,6 +1,6 @@
 
 module.exports = function dbCall(sql, knex, context) {
-  if (context) {
+  if (context && context.response) {
     context.set('X-SQL-Preview', context.response.get('X-SQL-Preview') + '%0A%0A' + sql.replace(/%/g, '%25').replace(/\n/g, '%0A'))
   }
   return knex.raw(sql).then(result => {

--- a/test-api/schema-paginated/ContextPost.js
+++ b/test-api/schema-paginated/ContextPost.js
@@ -1,0 +1,32 @@
+import {
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLInt
+} from 'graphql'
+import {
+  globalIdField,
+} from 'graphql-relay'
+import { nodeInterface } from './Node'
+import { q } from '../shared'
+
+const { DB } = process.env
+
+const ContextPost = new GraphQLObjectType({
+  description: 'A post from a user. This object is used in a context test and must be given a context.table to resolve.',
+  name: 'ContextPost',
+  interfaces: () => [nodeInterface],
+  sqlTable: (_, context) => `(SELECT * FROM ${q(context.table, DB)})`,
+  uniqueKey: 'id',
+  fields: () => ({
+    id: {
+      ...globalIdField(),
+      sqlDeps: ['id']
+    },
+    body: {
+      description: 'The content of the post',
+      type: GraphQLString
+    },
+  })
+})
+
+export default ContextPost

--- a/test-api/schema-paginated/Node.js
+++ b/test-api/schema-paginated/Node.js
@@ -31,4 +31,3 @@ const { nodeInterface, nodeField } = nodeDefinitions(
 )
 
 export { nodeInterface, nodeField }
-

--- a/test-api/schema-paginated/QueryRoot.js
+++ b/test-api/schema-paginated/QueryRoot.js
@@ -15,6 +15,7 @@ import knex from './database'
 import { User, UserConnection } from './User'
 import Sponsor from './Sponsor'
 import { nodeField } from './Node'
+import ContextPost from './ContextPost'
 
 import joinMonster from '../../src/index'
 import dbCall from '../data/fetch'
@@ -112,7 +113,17 @@ export default new GraphQLObjectType({
           .catch(done)
         }, options)
       }
+    },
+    contextPosts: {
+      type: new GraphQLList(ContextPost),
+        resolve: (parent, args, context, resolveInfo) => {
+          // use the callback version this time
+          return joinMonster(resolveInfo, context, (sql, done) => {
+            knex.raw(sql)
+              .then(data => done(null, data))
+              .catch(done)
+          }, options)
+        }
     }
   })
 })
-

--- a/test/relay.js
+++ b/test/relay.js
@@ -283,6 +283,19 @@ test('should handle a post without an author', async t => {
   t.deepEqual(expect, data)
 })
 
+test('should pass context to getNode resolver', async t => {
+  const query = `{
+    node(id: "${toGlobalId('ContextPost', 1)}") {
+      ... on ContextPost { body }
+    }
+  }`
+
+  const { data, errors } = await run(query, null, { table: 'posts' })
+  errCheck(t, errors)
+  const expect = { node: { body: 'If I could marry a programming language, it would be Haskell.' } }
+  t.deepEqual(expect, data)
+})
+
 test('should handle fragments recursively', async t => {
   const query = `
     {


### PR DESCRIPTION
Hey there! First time contributor, so sorry if things aren't exactly how you want. Feel free to tell me if you need anything changed.

I ran into an issue with resolving a node definition of an object whose table value relied on pulling something out of context and realized it was because the context is not passed to `queryAST.populateASTNode` in the `getNode` declaration. This PR fixes that and adds a test that queries an object through the node definition which grabs the table to query through a value in context.
 