### PR TITLE
Junction unique alias

### DIFF
--- a/src/stringifiers/dispatcher.js
+++ b/src/stringifiers/dispatcher.js
@@ -113,8 +113,7 @@ async function _stringifySqlAST(parent, node, prefix, context, selections, table
     break
   case 'composite':
     // If doing a batched junction, use the joining table name
-    const useJunctionTableName = !!idx(parent, _ => _.junction.sqlBatch)
-    if (useJunctionTableName) {
+    if (parent.type === 'table' && parent.name === idx(parent, _ => _.junction.sqlTable)) {
       parentTable = parent.as
     }
     selections.push(


### PR DESCRIPTION
When junction joining to the same table, we want to use the junction table when generating the unique composite key to ensure uniqueness of the rows returned. 

Similarly, when hydrating the data from a junction table we want id to be from the joining table, not the parent table.

Addresses part of the issue in #245 

```
SELECT
  ####### Will not generate a unique id ######
  CONCAT(`table1`.`id`, `table1`.`id`) AS `id#id`,
  `table2`.`id` AS `id`,
  `table2`.`col` AS `col`,
  ####### This will override the ID we care about ######
  `table1`.`id` AS `id`
FROM same_table `table1`
LEFT JOIN same_table `table2` ON `table1`.col = `table2`.col
```

becomes

```
SELECT
  CONCAT(`table2`.`id`, `table2`.`id`) AS `id#id`,
  `table2`.`id` AS `id`,
  `table2`.`col` AS `col`,
  `table1`.`id` AS `junc_id`
FROM same_table `table1`
LEFT JOIN same_table `table2` ON `table1`.col = `table2`.col
```