### PR TITLE
Set dialect mysql on knex client mysql2

### DIFF
--- a/test-api/schema-paginated/Node.js
+++ b/test-api/schema-paginated/Node.js
@@ -8,7 +8,7 @@ const options = {
   minify: process.env.MINIFY == 1
 }
 const { PAGINATE } = process.env
-if (knex.client.config.client === 'mysql') {
+if (knex.client.config.client === 'mysql' || knex.client.config.client === 'mysql2') {
   options.dialect = PAGINATE ? 'mysql8' : 'mysql'
 } else if (knex.client.config.client === 'pg') {
   options.dialect = 'pg'


### PR DESCRIPTION
# What I did
Set dialect mysql when knex client is [Mysql2](https://www.npmjs.com/package/mysql2)

# Why?
Knex also can set client mysql2. [Mysql2](https://www.npmjs.com/package/mysql2) is compatiable with mysql.