### PR TITLE
Call handleJoinedOneToManyPaginated when dialect has that

### DIFF
--- a/src/stringifiers/dispatcher.js
+++ b/src/stringifiers/dispatcher.js
@@ -178,7 +178,7 @@ async function handleTable(parent, node, prefix, context, selections, tables, wh
       await dialect.handleJoinedOneToManyPaginated(parent, node, context, tables, joinCondition)
 
     // limit has a highly similar approach to paginating
-    } else if (node.limit) {
+    } else if (node.limit && dialect.handleJoinedOneToManyPaginated) {
       node.args.first = node.limit
       await dialect.handleJoinedOneToManyPaginated(parent, node, context, tables, joinCondition)
     // otherwite, just a regular left join on the table


### PR DESCRIPTION
Mysql 5.7 and MariaDB also can run with limit.
So I changed `if` condition only when dialect has `handleJoinedOneToManyPaginated`.

Tested MariaDB with left join query, works very well.