### PR TITLE
fix connections inside union fragments are null

### DIFF
--- a/src/array-to-connection.js
+++ b/src/array-to-connection.js
@@ -16,6 +16,21 @@ function arrToConnection(data, sqlAST) {
       recurseOnObjInData(data, astChild)
     }
   }
+  if (sqlAST.typedChildren) {
+    for (let astType in sqlAST.typedChildren) {
+      if (Object.prototype.hasOwnProperty.call(sqlAST.typedChildren, astType)) {
+        for (let astChild of sqlAST.typedChildren[astType] || []) {
+          if (Array.isArray(data)) {
+            for (let dataItem of data) {
+              recurseOnObjInData(dataItem, astChild)
+            }
+          } else if (data) {
+            recurseOnObjInData(data, astChild)
+          }
+        }
+      }
+    }
+  }
   const pageInfo = {
     hasNextPage: false,
     hasPreviousPage: false


### PR DESCRIPTION
As corrected by @meticoeus at PR #402, connections inside fragments are not converted from arrays to pagination structure, resulting in `edges` and `pageInfo` fields null.

I've added a test to ensure correct behaviour on this in order to get it merged. Special thanks to @danielferragut for helping me at this task.

Fixes #401 