### PR TITLE
Replace stems/join-monster with join-monster/join-monster

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <!-- Use fully qualified URL for the images so they'll also be visible from the NPM page too -->
-![join-monster](https://raw.githubusercontent.com/stems/join-monster/master/docs/img/join_monster.png)
-[![npm version](https://badge.fury.io/js/join-monster.svg)](https://badge.fury.io/js/join-monster) [![Build Status](https://travis-ci.org/stems/join-monster.svg?branch=master)](https://travis-ci.org/stems/join-monster) [![Documentation Status](https://readthedocs.org/projects/join-monster/badge/?version=latest)](http://join-monster.readthedocs.io/en/latest/?badge=latest)
-[![Greenkeeper badge](https://badges.greenkeeper.io/stems/join-monster.svg)](https://greenkeeper.io/)
+![join-monster](https://raw.githubusercontent.com/join-monster/join-monster/master/docs/img/join_monster.png)
+[![npm version](https://badge.fury.io/js/join-monster.svg)](https://badge.fury.io/js/join-monster) [![Build Status](https://travis-ci.org/join-monster/join-monster.svg?branch=master)](https://travis-ci.org/join-monster/join-monster) [![Documentation Status](https://readthedocs.org/projects/join-monster/badge/?version=latest)](http://join-monster.readthedocs.io/en/latest/?badge=latest)
+[![Greenkeeper badge](https://badges.greenkeeper.io/join-monster/join-monster.svg)](https://greenkeeper.io/)
 
 ### Query Planning and Batch Data Fetching between GraphQL and SQL.
 
@@ -300,7 +300,7 @@ DATABASE_URL=postgres://$USER:$PASS@$HOST/$YOUR_DATABASE npm start
 
 Explore the schema, try out some queries, and see what the resulting SQL queries and responses look like in [our custom version of GraphiQL](https://github.com/acarl005/graphsiql)!
 
-![graphsiql](https://raw.githubusercontent.com/stems/join-monster/master/docs/img/graphsiql.png)
+![graphsiql](https://raw.githubusercontent.com/join-monster/join-monster/master/docs/img/graphsiql.png)
 
 **There's still a lot of work to do. Please feel free to fork and submit a Pull Request!**
 

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -9,7 +9,7 @@ Here is a picture of the SQL schema.
 ![schema-example](img/schema-sql.png)
 
 I'll omit the code to set up the SQL tables.
-[Here](https://github.com/stems/join-monster/blob/master/test-api/data/schema/sqlite3.sql) is an example of how it might be done.
+[Here](https://github.com/join-monster/join-monster/blob/master/test-api/data/schema/sqlite3.sql) is an example of how it might be done.
 Now let's look at how the GraphQL API inteface on top of this will look.
 
 ![schema-graphql](img/schema-graphql.png)

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -1,5 +1,5 @@
 ## Overview
-[Join Monster](https://github.com/stems/join-monster) fetches only the data you need - *nothing more, nothing less*, just like the original philosophy of GraphQL.
+[Join Monster](https://github.com/join-monster/join-monster) fetches only the data you need - *nothing more, nothing less*, just like the original philosophy of GraphQL.
 It reads the parsed GraphQL query, looks at your schema definition, and automatically generates the SQL that will fetch no more than what is required to fulfill the request.
 All data fetching for all resources can be done in one or a few queries using the power of `JOIN`s.
 
@@ -23,9 +23,9 @@ If one table's object type is nested as a field within another table's object ty
 
 ## Adding Metadata
 
-So [Join Monster](https://github.com/stems/join-monster) needs some additional metadata in order to write the right SQL. How does one declare these mappings, and unique keys, and joins, etc.?
+So [Join Monster](https://github.com/join-monster/join-monster) needs some additional metadata in order to write the right SQL. How does one declare these mappings, and unique keys, and joins, etc.?
 
-These are declared by decorating the schema definition with some additional properties that [Join Monster](https://github.com/stems/join-monster) will look for. Below is an example of  mapping the `User` object to an `accounts` table that joins on `posts` for a `Post` object. For details see the following **Usage** section.
+These are declared by decorating the schema definition with some additional properties that [Join Monster](https://github.com/join-monster/join-monster) will look for. Below is an example of  mapping the `User` object to an `accounts` table that joins on `posts` for a `Post` object. For details see the following **Usage** section.
 
 ```javascript
 const User = new GraphQLObjectType({
@@ -55,9 +55,9 @@ const User = new GraphQLObjectType({
 
 Join Monster provides a declarative API that lets you define **data requirements** on your object types and fields. By placing these properties directly on the schema definition, GraphQL effectively *becomes* your ORM because it is the mapping between the application and the data.
 
-Notice that most of these fields do not have resolvers. Most of the time, adding the SQL decorations will be enough. [Join Monster](https://github.com/stems/join-monster) fetches the data and converts it to the correct object tree structure with the expected property names so the child resolvers know where to find the data.
+Notice that most of these fields do not have resolvers. Most of the time, adding the SQL decorations will be enough. [Join Monster](https://github.com/join-monster/join-monster) fetches the data and converts it to the correct object tree structure with the expected property names so the child resolvers know where to find the data.
 
-Also notice the `immortal` field, which does have a resolver. This field demonstrates how not all the fields must come from the batch request. You can write custom resolvers like you normally would that gets data from anywhere else. [Join Monster](https://github.com/stems/join-monster) is just a way of fetching data, it will not hinder your ability to write your resolvers. You can also have your fields get data fron a column *and* apply a resolver to modify, format, or extend the data.
+Also notice the `immortal` field, which does have a resolver. This field demonstrates how not all the fields must come from the batch request. You can write custom resolvers like you normally would that gets data from anywhere else. [Join Monster](https://github.com/join-monster/join-monster) is just a way of fetching data, it will not hinder your ability to write your resolvers. You can also have your fields get data fron a column *and* apply a resolver to modify, format, or extend the data.
 
 ## Calling the Function
 

--- a/docs/problem.md
+++ b/docs/problem.md
@@ -118,6 +118,6 @@ Although we made the round-trip problem go away, what if another query doesn't e
 
 During the execution of this request, it will wastefully join on the comments! Now we're over-fetching (and over-joining). The resolving phase essentially becomes a bunch of property lookups for a conglomerate result we prepared in the top-level. Our database might be able to handle it now, but this approach will not scale to more complex schema. Consider a schema like this:
 
-![schema-complex](https://raw.githubusercontent.com/stems/join-monster/master/docs/img/schema-complex.png)
+![schema-complex](https://raw.githubusercontent.com/join-monster/join-monster/master/docs/img/schema-complex.png)
 
 Imagine doing all those joins up front. This is especially wasteful when client only wants a couple of those resources. We now have the inverse problem: **getting too much data.** We've also reduced the maintainability of our code. Changes to the schema will require changes to the SQL query that fetches all the data. Furthermore, there is the extra burden of converting the database result into the right Object shape, since many database drivers simply return a flat, tabular structure.

--- a/docs/pros-cons.md
+++ b/docs/pros-cons.md
@@ -1,6 +1,6 @@
 ## Benefits
 
-Using [Join Monster](https://github.com/stems/join-monster) provides the following benefits.
+Using [Join Monster](https://github.com/join-monster/join-monster) provides the following benefits.
 
 
 - **Batching** - Fetch all the data in a single database query. Cut down on network latency.
@@ -14,11 +14,11 @@ It solved a real performance bottleneck due to network latency for us. We consid
 
 ## Limitations
 
-There are some constraints on how your data model looks. We need to be able to make some assumptions in order to sensibly translate queries from a hierarchical structure to a relational one. Not all schemas will be able to allow [Join Monster](https://github.com/stems/join-monster) to handle all the data fetching, perhaps not in whole but in part.
+There are some constraints on how your data model looks. We need to be able to make some assumptions in order to sensibly translate queries from a hierarchical structure to a relational one. Not all schemas will be able to allow [Join Monster](https://github.com/join-monster/join-monster) to handle all the data fetching, perhaps not in whole but in part.
 
 It is not tested at high scale. Again, it is a prototyping tool at this point in time.  
 
-Because you aren't writing the queries yourself, you lose some freedom to do some performance tuning. [Join Monster](https://github.com/stems/join-monster), however, remains transparent about what SQL it actually produces - an important capability for judiciously choosing database indexes. The developer is still responsible for making the generated queries optimized by creating the right indexes for better query plans. You can `console.log` the SQL queries or run your Node.js process with the environment variable `DEBUG=join-monster` for some useful diagnostic information. Furthermore, you can use our [custom version of GraphiQL](https://github.com/acarl005/graphsiql) used in [the demo](https://join-monster.herokuapp.com/graphql?query=%7B%20users%20%7B%20%0A%20%20id%2C%20fullName%2C%20email%0A%20%20posts%20%7B%20id%2C%20body%20%7D%0A%7D%7D) to visualize the SQL.
+Because you aren't writing the queries yourself, you lose some freedom to do some performance tuning. [Join Monster](https://github.com/join-monster/join-monster), however, remains transparent about what SQL it actually produces - an important capability for judiciously choosing database indexes. The developer is still responsible for making the generated queries optimized by creating the right indexes for better query plans. You can `console.log` the SQL queries or run your Node.js process with the environment variable `DEBUG=join-monster` for some useful diagnostic information. Furthermore, you can use our [custom version of GraphiQL](https://github.com/acarl005/graphsiql) used in [the demo](https://join-monster.herokuapp.com/graphql?query=%7B%20users%20%7B%20%0A%20%20id%2C%20fullName%2C%20email%0A%20%20posts%20%7B%20id%2C%20body%20%7D%0A%7D%7D) to visualize the SQL.
 
 ![graphsiql](img/graphsiql.png)
 
@@ -27,7 +27,7 @@ Because you aren't writing the queries yourself, you lose some freedom to do som
 
 [DataLoader](https://github.com/facebook/dataloader) is Facebook's own solution for batch requests. It also caches individual entities. It's a simple and general tool for data fetching.
 
-[Join Monster](https://github.com/stems/join-monster) is able to specialize for SQL, so you can avoid manually writing the queries (more configuring less programming). Data loader only batches requests for one resource, e.g. batching requests for users, or posts, etc. Join Monster can batch **everything** into one trip.
+[Join Monster](https://github.com/join-monster/join-monster) is able to specialize for SQL, so you can avoid manually writing the queries (more configuring less programming). Data loader only batches requests for one resource, e.g. batching requests for users, or posts, etc. Join Monster can batch **everything** into one trip.
 
 DataLoader derives its performance benefit from caching. Caching opens a can of worms. You have to think about cache invalidation, memory pressure, loading the cache, etc. For us, the batching was such a win that our performance issues were solved. The cache is complexity that we didn't need. This means less developer labor and cognitive burden.
 

--- a/docs/warnings.md
+++ b/docs/warnings.md
@@ -7,7 +7,7 @@
   </p>
 </div>
 
-[Join Monster](https://github.com/stems/join-monster) uses unique keys for identification and de-duplicating objects. It never checks for any constraints in SQL. It assumes they are unique and will silently corrupt the data if they are not. If, for example, one field is a `new GraphQLList(SomeObject)` and that `SomeObject` contains a sub-field that is the same as other instances in this list, each instance will have a reference to the same object. If two rows have the same `id`, Join Monster will assume these are the same object and it can make multiple references to only one of these objects. Basically, the first instance of that `id` will overwrite any other places in which the other object would occur.
+[Join Monster](https://github.com/join-monster/join-monster) uses unique keys for identification and de-duplicating objects. It never checks for any constraints in SQL. It assumes they are unique and will silently corrupt the data if they are not. If, for example, one field is a `new GraphQLList(SomeObject)` and that `SomeObject` contains a sub-field that is the same as other instances in this list, each instance will have a reference to the same object. If two rows have the same `id`, Join Monster will assume these are the same object and it can make multiple references to only one of these objects. Basically, the first instance of that `id` will overwrite any other places in which the other object would occur.
 
 It also uses keys for [Keyset Pagination](/relay/#3-keyset-paging). The keys are what generate the cursors. If a cursor is not unique, it might skip a row if it has the same cursor as another item at the edge of a page.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: Join Monster
 site_description: A GraphQL-to-SQL execution layer.
-repo_url: https://github.com/stems/join-monster
+repo_url: https://github.com/join-monster/join-monster
 site_favicon: img/join_monster.ico
 theme: readthedocs
 extra_javascript:

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/stems/join-monster.git"
+    "url": "git+https://github.com/join-monster/join-monster.git"
   },
   "keywords": [
     "graphql",
@@ -65,9 +65,9 @@
   ],
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/stems/join-monster/issues"
+    "url": "https://github.com/join-monster/join-monster/issues"
   },
-  "homepage": "https://github.com/stems/join-monster#readme",
+  "homepage": "https://github.com/join-monster/join-monster#readme",
   "peerDependencies": {
     "graphql": "0.6 || 0.7 || 0.8 || 0.9 || 0.10 || 0.11 || 0.12 || 0.13"
   },

--- a/src/README.md
+++ b/src/README.md
@@ -11,7 +11,7 @@ Each call to `joinMonster` has the following phases:
 1. Hydrate the data.
 1. Check SQL AST to see if they have any more batches to compile. If yes, repeat steps 4-8.
 
-![internals](https://raw.githubusercontent.com/stems/join-monster/master/docs/img/internals.png)
+![internals](https://raw.githubusercontent.com/join-monster/join-monster/master/docs/img/internals.png)
 
 This whole process begins when you call `joinMonster` and pass it the `resolveInfo`.
 Join Monster looks at the parsed query AST, fragments, variables, your schema definition, and everything needed to query and hydrate the data. After traversing the whole query AST, an intermediate representation is generated: a hybrid of the GraphQL query and the SQL metadata. We call it the **SQL AST**.


### PR DESCRIPTION
I think stems/join-monster is the old repo though, please tell me if I'm wrong.

---

I'm confused a bit because https://join-monster.readthedocs.io/en/latest/ indicates https://github.com/stems/join-monster