### PR TITLE
GraphQL v15 config via extensions

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -104,5 +104,8 @@ if [ $PG = 1 ]; then
   STRATEGY=mix MINIFY=1 npm run testpg-paging
 fi
 
+echo -e "${YELLOW} testing typescript definitions${NC}"
+npm run testtsd
+
 echo -e "${GREEN} PASSED ${NC}"
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,42 +1,109 @@
 ### v3.0.0 (unreleased)
 
 **Breaking changes:**
-- Update GraphQL requirement to version 15, which supports a new `extensions` property where join-monster config lives. The config keys and values are unchanged, but they must be nested under an `extensions: { joinMonster: ... }}` property on the GraphQLObjectTypes and fields using join-monster. For more information, see the upgrade guide:
+
+- Update GraphQL requirement to version 15, which supports a new `extensions` property where join-monster config lives. The config keys and values are largely unchanged, but now they must be nested under an `extensions: { joinMonster: ... }}` property on the GraphQLObjectTypes and fields using join-monster. To upgrade, you must move any non-standard keys off of your `GraphQLObjectType`s or field configs into the `extensions` of the same field. So, something like this:
+
+```javascript
+const User = new GraphQLObjectType({
+  name: 'User',
+  sqlTable: 'users',
+  uniqueKey: 'id',
+  fields: () => ({
+    id: {
+      type: GraphQLInt
+    },
+    email: {
+      type: GraphQLString,
+      sqlColumn: 'email_address'
+    },
+  })
+}
+```
+
+becomes this:
+
+```javascript
+const User = new GraphQLObjectType({
+  name: 'User',
+  extensions: {
+    joinMonster: {
+      sqlTable: 'users',
+      uniqueKey: 'id'
+    }
+  },
+  fields: () => ({
+    id: {
+      type: GraphQLInt
+    },
+    email: {
+      type: GraphQLString,
+      extensions: {
+        joinMonster: {
+          sqlColumn: 'email_address'
+        }
+      }
+    }
+  })
+}
+```
+
+The resulting code is sadly more verbose, but the only supported way of layering in extra information to a GraphQL schema going forward, and safer in the presence of other GraphQL schema extensions.
+
+**Note**: There are two configuration keys which have changed beyond just becoming nested in the `extensions` property:
+
+- `jmIgnoreAll` has been renamed to `ignoreAll`
+- `jmIgnoreTable` has been renamed to `ignoreTable`
+
+The old names for these configuration options will no longer work so please be sure to update.
 
 ### v2.1.2 (May 25, 2020)
+
 #### Fixed
+
 - Connections inside union fragments [#407](https://github.com/join-monster/join-monster/pull/407)
 
 ### v2.1.1 (Nov. 21, 2019)
+
 #### Fixed
+
 - Updated vulnerable version of lodash (`eed0264`)
 
 ### v2.1.0 (Aug. 25, 2018)
+
 - Numerous bug fixes
 - TypeScript type definitions
 - New 'mysql8' dialect which supports some pagination
 
 ### v2.0.13 (Sep. 4, 2017)
+
 - Don't write to debug module unless it's actually enabled.
 
 ### v2.0.9 (Aug. 23, 2017)
+
 - Properly format instances of Buffer.
 
 ### v2.0.8 (Aug. 16, 2017)
+
 - Support duplicate fields without aliases off the query root type.
 
 ### v2.0.6 (Aug. 11, 2017)
+
 - Add SQL AST node to sqlJoin callback signature.
 
 ### v2.0.5 (Aug. 11, 2017)
+
 - Remove the use of `Proxy` to improve compatibility.
 
 ### v2.0.4 (Aug. 8, 2017)
+
 - Add option for custom dialect modules.
 - Various bug fixes.
 
 ### v2.0.0 (Jun. 25, 2017)
+
 **New features:**
+
 - `LIMIT` functionality, supported on all fields.
 - Fetch columns from junction tables.
 - For fields with junctions, you can now specify `WHERE` and `ORDER BY` clauses on the junction table or the main table, including paginated fields.
@@ -44,6 +111,7 @@
 - Better ability to write `where` functions that depend on args and info from the parent/ancestors.
 
 **Breaking changes:**
+
 - Fields with junctions have a new interface in order to support the new features.
 - Any `where`, `orderBy`, and `sortKey` on many-to-many paginated fields used to be applied to the junction table. This has changed, and will be applied to the main table instead in order to be consistent with non-paginated junctions. If the old behavior is desired, you can nest those properties inside the `junction` object, which is part of the new API.
 - Change 4th parameter of `where` and `sqlExpr` to the field's SQL AST Node, which is a lot more useful.
@@ -139,30 +207,36 @@
   //  created_at: 'DESC',
   //  id: 'ASC'
   //}
-  
+
   // you could also place a `where` at either
 }
 ```
 
 ### v1.2.1 (Mar. 28, 2017)
+
 - Add `jmIgnoreAll` and `jmIgnoreTable`.
 - Make `sqlTable` a thunk.
 - Bug fix with recursively nested union and interface type fragments.
 - Bug fix with for batch on a single-type parent.
 
 ### v1.2.0 (Mar. 16, 2017)
+
 - Add an API for GraphQLInterfaceType
 
 ### v1.1.1 (Mar. 13, 2017)
+
 - Add an API for GraphQLUnionType
 
 ### v1.1.0 (Mar. 11, 2017)
+
 - Add Oracle as supported dialect.
 
 ### v1.0.1 (Mar. 8, 2017)
+
 - Add `ORDER BY` support for non-paginated fields.
 
 ### v1.0.0 (Feb. 28, 2017)
+
 - Batching capabilities added.
 - MariaDB can do pagination on batches.
 - `sqlExpr` can now be asynchronous.
@@ -178,94 +252,120 @@
 - `joinTable` is deprecated. It was renamed to `junctionTable` to avoid over-use of the word "join".
 - `'standard'` dialect is deprecated because nothing really implements the standard. The new default is `'sqlite3'`.
 
-
-
 ### v0.9.10 (Feb. 16, 2017)
+
 - Bug fixes with recursive fragments and argument parsing.
 
 ### v0.9.9 (Feb. 3, 2017)
+
 - Add `context` to the `sqlJoin` parameters.
 - Support async in `sqlJoin`.
 
 ### v0.9.8 (Feb. 2, 2017)
+
 - Expose parent table aliases to `where` function.
 
 ### v0.9.5 (Jan. 24, 2017)
+
 - Fix bug for Postgres where `CONCAT` returns `''` instead of `NULL`.
 
 ### v0.9.4 (Jan. 22, 2017)
+
 - Expose GraphQL args to `sqlJoin` function.
 
 ### v0.9.3 (Jan. 14, 2017)
+
 - Add support for fragments on interface types.
 
 ### v0.9.2 (Jan. 5, 2017)
+
 - Fix bug when composite keys contain timestamps or dates in PG dialect.
 - Patch SQL injection risk.
 
 ### v0.9.0 (Jan. 4, 2017)
+
 - More automatic fetching using `getNode` implemented.
 
 ### v0.8.0 (Dec. 19, 2016)
+
 - Expose the `getSQL` method for getting only the converted SQL.
 
 ### v0.7.0 (Dec. 16, 2016)
+
 - Introducing raw SQL expressions for computed columns.
 
 ### v0.6.0 (Dec. 2, 2016)
+
 - Support asynchronicity in the `where` function.
 
 ### v0.5.8 (Dec. 1, 2016)
+
 - Add null check to node interface handler.
 
 ### v0.5.7 (Nov. 29, 2016)
+
 - Fix bug with `WHERE` conditions on paginated fields.
 
 ### v0.5.6 (Nov. 14, 2016)
+
 - Fix bug with query variables on the Node interface.
 
 ### v0.5.5 (Nov. 13, 2016)
+
 - Add support for dynamic sort keys on paginated fields. Sort keys can now be functions that receive the GraphQL arguments.
 
 ### v0.5.4 (Nov. 10, 2016)
+
 - Add support for query variables.
 
 ### v0.5.2 (Nov. 6, 2016)
+
 - Relay connection type names are no longer required to end with "Connection".
 
 ### v0.5.1 (Nov. 5, 2016)
+
 - Fix problem with introspection queries.
 
 ### v0.5.0 (Nov. 4, 2016)
+
 - Add dialect for MySQL/MariaDB.
 
 ### v0.4.1 (Oct 21, 2016)
+
 - Fix bug with de-duplication of objects.
 
 ### v0.4.0 (Oct 20, 2016)
+
 - Add Postgres dialect option.
 - Support SQL pagination based on integer offsets.
 - Support SQL pagination based on a sort key(s).
 
 ### v0.3.7 (Oct 16, 2016)
+
 - Fix bug with nested fragments.
 
 ### v0.3.6 (Oct 13, 2016)
+
 - Option to minify the raw data column names.
 
 ### v0.3.5 (Oct 9, 2016)
+
 - Add test coverage tools.
 
 ### v0.3.4 (Oct 6, 2016)
+
 - Add helper method for getting data for Relay's Node type.
 - Fix bug with Union and Interface types.
 
 ### v0.3.2 (Oct 5, 2016)
+
 - Add support for specifying schema names for your SQL tables.
 
 ### v0.3.1 (Oct 4, 2016)
+
 - Detect Relay connection type and fetch data for it.
 
 ### v0.3.0 (Oct 3, 2016)
+
 - Unique keys required for every table. Necessary for achieving good performance during object shaping/nesting.
 - Composite keys supported for the unique key.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,9 +1,14 @@
+### v3.0.0 (unreleased)
+
+**Breaking changes:**
+- Update GraphQL requirement to version 15, which supports a new `extensions` property where join-monster config lives. The config keys and values are unchanged, but they must be nested under an `extensions: { joinMonster: ... }}` property on the GraphQLObjectTypes and fields using join-monster. For more information, see the upgrade guide:
+
 ### v2.1.2 (May 25, 2020)
-#### Fixed 
+#### Fixed
 - Connections inside union fragments [#407](https://github.com/join-monster/join-monster/pull/407)
 
 ### v2.1.1 (Nov. 21, 2019)
-#### Fixed 
+#### Fixed
 - Updated vulnerable version of lodash (`eed0264`)
 
 ### v2.1.0 (Aug. 25, 2018)

--- a/docs/aggregation.md
+++ b/docs/aggregation.md
@@ -13,8 +13,13 @@ const Post = new GraphQLObjectType({
       description: 'The number of comments on this post',
       type: GraphQLInt,
       // use a correlated subquery in a raw SQL expression to do things like aggregation
-      sqlExpr: postTable => `(SELECT count(*) FROM comments WHERE post_id = ${postTable}.id AND archived = FALSE)`
-    },
+      extensions: {
+        joinMonster: {
+          sqlExpr: postTable =>
+            `(SELECT count(*) FROM comments WHERE post_id = ${postTable}.id AND archived = FALSE)`
+        }
+      }
+    }
   })
 })
 ```
@@ -57,8 +62,13 @@ const Post = new GraphQLObjectType({
   fields: () => ({
     commentsWithoutJoin: {
       type: new GraphQLList(SimpleComment),
-      sqlExpr: postTable => `(SELECT json_agg(comments) FROM comments WHERE comments.post_id = ${postTable}.id AND comments.archived = FALSE)`
-    },
+      extensions: {
+        joinMonster: {
+          sqlExpr: postTable =>
+            `(SELECT json_agg(comments) FROM comments WHERE comments.post_id = ${postTable}.id AND comments.archived = FALSE)`
+        }
+      }
+    }
   })
 })
 ```
@@ -76,7 +86,7 @@ This should work without any additional data munging if you're using `knex`, as 
       commentsWithoutJoin {
         id
         body
-      	authorId
+        authorId
       }
     }
   }
@@ -98,4 +108,3 @@ FROM accounts AS "user"
 LEFT JOIN posts AS "posts" ON "user".id = "posts".author_id
 WHERE "user".id = 2
 ```
-

--- a/docs/arbitrary-depth.md
+++ b/docs/arbitrary-depth.md
@@ -19,7 +19,12 @@ const Post = new GraphQLObjectType({
     author: {
       description: 'The user that created the post',
       type: User,
-      sqlJoin: (postTable, userTable, args, context) => `${postTable}.author_id = ${userTable}.id`
+      extensions: {
+        joinMonster: {
+          sqlJoin: (postTable, userTable, args, context) =>
+            `${postTable}.author_id = ${userTable}.id`
+        }
+      }
     }
   })
 })
@@ -31,12 +36,22 @@ const Comment = new GraphQLObjectType({
     post: {
       description: 'The post that the comment belongs to',
       type: Post,
-      sqlJoin: (commentTable, postTable) => `${commentTable}.post_id = ${postTable}.id`
+      extensions: {
+        joinMonster: {
+          sqlJoin: (commentTable, postTable) =>
+            `${commentTable}.post_id = ${postTable}.id`
+        }
+      }
     },
     author: {
       description: 'The user who wrote the comment',
       type: User,
-      sqlJoin: (commentTable, userTable) => `${commentTable}.author_id = ${userTable}.id`
+      extensions: {
+        joinMonster: {
+          sqlJoin: (commentTable, userTable) =>
+            `${commentTable}.author_id = ${userTable}.id`
+        }
+      }
     }
   })
 })
@@ -46,14 +61,22 @@ Now you can get the comments the user has written, the post on which each commen
 
 ```graphql
 {
-  users { 
-    id, email, fullName
+  users {
+    id
+    email
+    fullName
     comments {
-      id, body
-      author { fullName }
+      id
+      body
+      author {
+        fullName
+      }
       post {
-        id, body
-        author { fullName }
+        id
+        body
+        author {
+          fullName
+        }
       }
     }
   }
@@ -71,11 +94,21 @@ const User = new GraphQLObjectType({
     //...
     posts: {
       type: new GraphQLList(Post),
-      sqlJoin: (userTable, postTable, args) => `${userTable}.id = ${postTable}.author_id`
+      extensions: {
+        joinMonster: {
+          sqlJoin: (userTable, postTable, args) =>
+            `${userTable}.id = ${postTable}.author_id`
+        }
+      }
     },
     comments: {
       type: new GraphQLList(Comment),
-      sqlJoin: (userTable, commentTable, args) => `${userTable}.id = ${commentTable}.author_id`
+      extensions: {
+        joinMonster: {
+          sqlJoin: (userTable, commentTable, args) =>
+            `${userTable}.id = ${commentTable}.author_id`
+        }
+      }
     }
   })
 })
@@ -91,15 +124,18 @@ const Post = new GraphQLObjectType({
     comments: {
       description: 'The comments on this post',
       type: new GraphQLList(Comment),
-      // the JOIN condition also checks that the comment is not archived
-      sqlJoin: (postTable, commentTable) => `${postTable}.id = ${commentTable}.post_id AND ${commentTable}.archived = FALSE`,
+      extensions: {
+        joinMonster: {
+          // the JOIN condition also checks that the comment is not archived
+          sqlJoin: (postTable, commentTable) =>
+            `${postTable}.id = ${commentTable}.post_id AND ${commentTable}.archived = FALSE`
+        }
+      }
     }
   })
 })
-
 ```
 
 Again, the data is all fetched in a single query thanks to `JOIN`s.
 However, doing all these joins can be cumbersome on the database.
 We can split it into two, or perhaps more, separate queries to reduce the number of joins in the next section.
-

--- a/docs/batch-many-many.md
+++ b/docs/batch-many-many.md
@@ -12,18 +12,23 @@ const User = new GraphQLObjectType({
     following: {
       description: 'Users that this user is following',
       type: new GraphQLList(User),
-      // batching many-to-many is supported too
-      junction: {
-        sqlTable: 'relationships',
-        // this table has no primary key, but the combination of these two columns is unique
-        uniqueKey: [ 'follower_id', 'followee_id' ],
-        sqlBatch: {
-          // the matching column in the junction table
-          thisKey: 'follower_id',
-          // the column to match in the user table
-          parentKey: 'id',
-          // how to join the related table to the junction table
-          sqlJoin: (junctionTable, followeeTable) => `${junctionTable}.followee_id = ${followeeTable}.id`
+      extensions: {
+        joinMonster: {
+          // batching many-to-many is supported too
+          junction: {
+            sqlTable: 'relationships',
+            // this table has no primary key, but the combination of these two columns is unique
+            uniqueKey: ['follower_id', 'followee_id'],
+            sqlBatch: {
+              // the matching column in the junction table
+              thisKey: 'follower_id',
+              // the column to match in the user table
+              parentKey: 'id',
+              // how to join the related table to the junction table
+              sqlJoin: (junctionTable, followeeTable) =>
+                `${junctionTable}.followee_id = ${followeeTable}.id`
+            }
+          }
         }
       }
     }
@@ -37,4 +42,3 @@ In addition to the changes made on the previous page, the plan now has 3 databas
 ![query-plan-3](img/query-plan-3.png)
 
 Requests for the followees and for the comments are independent, and are sent concurrently.
-

--- a/docs/batch-one-many.md
+++ b/docs/batch-one-many.md
@@ -14,17 +14,21 @@ const Post = new GraphQLObjectType({
     comments: {
       description: 'The comments on this post',
       type: new GraphQLList(Comment),
-      // instead of doing yet another JOIN, we'll get these comments in a separate batch
-      // sqlJoin: (postTable, commentTable) => `${postTable}.id = ${commentTable}.post_id AND ${commentTable}.archived = FALSE`,
-      sqlBatch: {
-        // which column to match up to the users
-        thisKey: 'post_id',
-        // the other column to compare to
-        parentKey: 'id'
-      },
-      // sqlBatch works with the `where` function too. get only non-archived comments
-      where: table => `${table}.archived = FALSE`
-    },
+      extensions: {
+        joinMonster: {
+          // instead of doing yet another JOIN, we'll get these comments in a separate batch
+          // sqlJoin: (postTable, commentTable) => `${postTable}.id = ${commentTable}.post_id AND ${commentTable}.archived = FALSE`,
+          sqlBatch: {
+            // which column to match up to the users
+            thisKey: 'post_id',
+            // the other column to compare to
+            parentKey: 'id'
+          },
+          // sqlBatch works with the `where` function too. get only non-archived comments
+          where: table => `${table}.archived = FALSE`
+        }
+      }
+    }
   })
 })
 ```
@@ -91,4 +95,3 @@ Two database queries are made regardless of the number of posts, another way to 
 
 Although this also works perfectly fine for a one-to-one relation, it is not recommended.
 Not much is gained by batching on a one-to-one since using a simple `JOIN` would not burden the database greatly.
-

--- a/docs/field-metadata.md
+++ b/docs/field-metadata.md
@@ -12,13 +12,21 @@ const User = new GraphQLObjectType({
     },
     email: {
       type: GraphQLString,
-      // if the column name is different, it must be specified
-      sqlColumn: 'email_address'
+      extensions: {
+        joinMonster: {
+          // if the column name is different, it must be specified
+          sqlColumn: 'email_address'
+        }
+      }
     },
     idEncoded: {
       description: 'The ID base-64 encoded',
       type: GraphQLString,
-      sqlColumn: 'id',
+      extensions: {
+        joinMonster: {
+          sqlColumn: 'id'
+        }
+      },
       // this field uses a sqlColumn and applies a resolver function on the value
       // if a resolver is present, the `sqlColumn` MUST be specified even if it is the same name as the field
       resolve: user => toBase64(user.id)
@@ -52,11 +60,15 @@ const User = new GraphQLObjectType({
   //...
   fields: () => ({
     fullName: {
-      description: 'A user\'s first and last name',
+      description: "A user's first and last name",
       type: GraphQLString,
-      // perhaps there is no 1-to-1 mapping of field to column
-      // this field depends on multiple columns
-      sqlDeps: [ 'first_name', 'last_name' ],
+      extensions: {
+        joinMonster: {
+          // perhaps there is no 1-to-1 mapping of field to column
+          // this field depends on multiple columns
+          sqlDeps: ['first_name', 'last_name']
+        }
+      },
       resolve: user => `${user.first_name} ${user.last_name}`
     }
   })
@@ -71,15 +83,22 @@ const User = new GraphQLObjectType({
   fields: () => ({
     capitalizedLastName: {
       type: GraphQLString,
-      // do a computed column in SQL with raw expression
-      sqlExpr: (table, args) => `UPPER(${table}.last_name)`
+      extensions: {
+        joinMonster: {
+          // do a computed column in SQL with raw expression
+          sqlExpr: (table, args) => `UPPER(${table}.last_name)`
+        }
+      }
     },
     fullNameAnotherWay: {
       description: 'Another way we can get the full name.',
       type: GraphQLString,
-      sqlExpr: table => `${table}.first_name || ' ' || ${table}.last_name`
-    },
+      extensions: {
+        joinMonster: {
+          sqlExpr: table => `${table}.first_name || ' ' || ${table}.last_name`
+        }
+      }
+    }
   })
 })
 ```
-

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -35,11 +35,19 @@ const User = new GraphQLObjectType({
   fields: () => ({
     id: {
       type: GraphQLInt,
-      sqlColumn: 'id'
+      extensions: {
+        joinMonster: {
+          sqlColumn: 'id'
+        }
+      }
     },
     email: {
       type: GraphQLString,
-      sqlColumn: 'email_address'
+      extensions: {
+        joinMonster: {
+          sqlColumn: 'email_address'
+        }
+      }
     },
     immortal: {
       type: graphQLBoolean,
@@ -47,7 +55,12 @@ const User = new GraphQLObjectType({
     },
     posts: {
       type: new GraphQLList(Post),
-      sqlJoin: (userTable, postTable) => `${userTable}.id = ${postTable}.author_id`
+      extensions: {
+        joinMonster: {
+          sqlJoin: (userTable, postTable) =>
+            `${userTable}.id = ${postTable}.author_id`
+        }
+      }
     }
   })
 })
@@ -76,4 +89,3 @@ users: {
   }
 }
 ```
-

--- a/docs/map-to-table.md
+++ b/docs/map-to-table.md
@@ -7,9 +7,15 @@ We also need a unique identifier so it's unambiguous which objects are distinct 
 ```javascript
 const User = new GraphQLObjectType({
   name: 'User',
-  sqlTable: 'accounts', // the SQL table for this object type is called "accounts"
-  uniqueKey: 'id', // id is different for every row
-  fields: () => ({ /*...*/ })
+  extensions: {
+    joinMonster: {
+      sqlTable: 'accounts', // the SQL table for this object type is called "accounts"
+      uniqueKey: 'id' // id is different for every row
+    }
+  },
+  fields: () => ({
+    /*...*/
+  })
 })
 ```
 
@@ -20,9 +26,15 @@ If your table is on a SQL schema that is not the default, e.g. `public`, you can
 ```javascript
 const User = new GraphQLObjectType({
   name: 'User',
-  sqlTable: 'public."Accounts"', // the SQL table is on the schema "public" called "Accounts"
-  uniqueKey: 'id',
-  fields: () => ({ /*...*/ })
+  extensions: {
+    joinMonster: {
+      sqlTable: 'public."Accounts"', // the SQL table is on the schema "public" called "Accounts"
+      uniqueKey: 'id'
+    }
+  },
+  fields: () => ({
+    /*...*/
+  })
 })
 ```
 
@@ -31,9 +43,15 @@ The `sqlTable` can generalize to any **table expression**. Instead of a physical
 ```javascript
 const User = new GraphQLObjectType({
   name: 'User',
-  sqlTable: '(SELECT * FROM accounts WHERE active = 1)', // this can be an expression that generates a TABLE
-  uniqueKey: 'id',
-  fields: () => ({ /*...*/ })
+  extensions: {
+    joinMonster: {
+      sqlTable: '(SELECT * FROM accounts WHERE active = 1)', // this can be an expression that generates a TABLE
+      uniqueKey: 'id'
+    }
+  },
+  fields: () => ({
+    /*...*/
+  })
 })
 ```
 
@@ -59,8 +77,14 @@ Just make `uniqueKey` an array of string instead of a string. Join Monster will 
 ```javascript
 const User = new GraphQLObjectType({
   name: 'User',
-  sqlTable: 'accounts',
-  uniqueKey: [ 'generation', 'first_name', 'last_name' ],
-  fields: () => ({ /*...*/ })
+  extensions: {
+    joinMonster: {
+      sqlTable: 'accounts',
+      uniqueKey: ['generation', 'first_name', 'last_name']
+    }
+  },
+  fields: () => ({
+    /*...*/
+  })
 })
 ```

--- a/docs/order-by.md
+++ b/docs/order-by.md
@@ -10,12 +10,17 @@ const User = new GraphQLObjectType({
     //...
     comments: {
       type: new GraphQLList(Comment),
-      // order these alphabetically, then by "id" if the comment body is the same
-      orderBy: {
-        body: 'asc',
-        id: 'desc'
-      },
-      sqlJoin: (userTable, commentTable, args) => `${userTable}.id = ${commentTable}.author_id`
+      extensions: {
+        joinMonster: {
+          // order these alphabetically, then by "id" if the comment body is the same
+          orderBy: {
+            body: 'asc',
+            id: 'desc'
+          },
+          sqlJoin: (userTable, commentTable, args) =>
+            `${userTable}.id = ${commentTable}.author_id`
+        }
+      }
     }
   })
 })
@@ -25,11 +30,15 @@ const QueryRoot = new GraphQLObjectType({
   fields: () => ({
     users: {
       type: new GraphQLList(User),
-      orderBy: {
-        id: 'asc'
-      },
-      resolve: (parent, args, context, resolveInfo) => {
-        // joinMonster
+      extensions: {
+        joinMonster: {
+          orderBy: {
+            id: 'asc'
+          },
+          resolve: (parent, args, context, resolveInfo) => {
+            // joinMonster
+          }
+        }
       }
     }
   })
@@ -78,13 +87,18 @@ const User = new GraphQLObjectType({
       args: {
         by: { type: ColumnEnum }
       },
-      orderBy: args => {
-        const sortBy = args.by || 'id'
-        return {
-          [sortBy]: 'desc'
+      extensions: {
+        joinMonster: {
+          orderBy: args => {
+            const sortBy = args.by || 'id'
+            return {
+              [sortBy]: 'desc'
+            }
+          },
+          sqlJoin: (userTable, commentTable, args) =>
+            `${userTable}.id = ${commentTable}.author_id`
         }
-      },
-      sqlJoin: (userTable, commentTable, args) => `${userTable}.id = ${commentTable}.author_id`
+      }
     }
   })
 })
@@ -99,19 +113,24 @@ const User = new GraphQLObjectType({
     //...
     following: {
       type: new GraphQLList(User),
-      // order by the user id
-      orderBy: { id: 'DESC' },
-      junction: {
-        sqlTable: 'relationships',
-        // this would have been equivalent
-        //orderBy: { followee_id: 'DESC' },
-        sqlJoins: [
-          (followerTable, junctionTable, args) => `${followerTable}.id = ${junctionTable}.follower_id`,
-          (junctionTable, followeeTable, args) => `${junctionTable}.followee_id = ${followeeTable}.id`
-        ]
+      extensions: {
+        joinMonster: {
+          // order by the user id
+          orderBy: { id: 'DESC' },
+          junction: {
+            sqlTable: 'relationships',
+            // this would have been equivalent
+            //orderBy: { followee_id: 'DESC' },
+            sqlJoins: [
+              (followerTable, junctionTable, args) =>
+                `${followerTable}.id = ${junctionTable}.follower_id`,
+              (junctionTable, followeeTable, args) =>
+                `${junctionTable}.followee_id = ${followeeTable}.id`
+            ]
+          }
+        }
       }
     }
   })
 })
 ```
-

--- a/docs/relay.md
+++ b/docs/relay.md
@@ -22,8 +22,12 @@ const User = new GraphQLObjectType({
     globalId: {
       description: 'The global ID for the Relay spec',
       ...globalIdField(),
-      sqlDeps: [ 'id' ]
-    },
+      extensions: {
+        joinMonster: {
+          sqlDeps: ['id']
+        }
+      }
+    }
     //...
   })
 })
@@ -90,4 +94,3 @@ const { nodeInterface, nodeField } = nodeDefinitions(
   obj => obj.__type__
 )
 ```
-

--- a/docs/start-joins.md
+++ b/docs/start-joins.md
@@ -33,9 +33,14 @@ const User = new GraphQLObjectType({
     //...
     comments: {
       type: new GraphQLList(Comment),
-      // a function to generate the join condition from the table aliases
-      // NOTE: you must double-quote any case-sensitive column names the table aliases are already quoted
-      sqlJoin: (userTable, commentTable, args) => `${userTable}.id = ${commentTable}.author_id`
+      extensions: {
+        joinMonster: {
+          // a function to generate the join condition from the table aliases
+          // NOTE: you must double-quote any case-sensitive column names the table aliases are already quoted
+          sqlJoin: (userTable, commentTable, args) =>
+            `${userTable}.id = ${commentTable}.author_id`
+        }
+      }
     }
   })
 })

--- a/docs/where.md
+++ b/docs/where.md
@@ -20,8 +20,12 @@ const QueryRoot = new GraphQLObjectType({
       args: {
         id: { type: new GraphQLNonNull(GraphQLInt) }
       },
-      where: (usersTable, args, context) => {
-        return `${usersTable}.id = ${args.id}`
+      extensions: {
+        joinMonster: {
+          where: (usersTable, args, context) => {
+            return `${usersTable}.id = ${args.id}`
+          }
+        }
       },
       resolve: (parent, args, context, resolveInfo) => {
         return joinMonster(resolveInfo, {}, sql => {
@@ -37,7 +41,7 @@ Now you can handle queries like this, which return a single user.
 
 ```graphql
 {
-  user(id: 1) { 
+  user(id: 1) {
     id
     email
     fullName
@@ -61,9 +65,13 @@ const QueryRoot = new GraphQLObjectType({
       args: {
         lastName: GraphQLString
       },
-      where: (usersTable, args, context) => {
-        return escape(`${usersTable}.last_name = %L`, args.lastName)
-      },
+      extensions: {
+        joinMonster: {
+          where: (usersTable, args, context) => {
+            return escape(`${usersTable}.last_name = %L`, args.lastName)
+          }
+        }
+      }
       // ...
     }
   })
@@ -87,8 +95,12 @@ For example, you can pass in the ID of the logged in user to incorporate it into
       return knex.raw(sql)
     })
   },
-  where: (usersTable, args, context) => {
-    return `${usersTable}.id = ${context.id}`
+  extensions: {
+    joinMonster: {
+      where: (usersTable, args, context) => {
+        return `${usersTable}.id = ${context.id}`
+      }
+    }
   }
 }
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -3182,6 +3182,12 @@
       "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
       "dev": true
     },
+    "@types/minimist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY=",
+      "dev": true
+    },
     "@types/node": {
       "version": "14.0.11",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.11.tgz",
@@ -4247,6 +4253,17 @@
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "dev": true
     },
+    "camelcase-keys": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
+      "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.3.1",
+        "map-obj": "^4.0.0",
+        "quick-lru": "^4.0.1"
+      }
+    },
     "caniuse-lite": {
       "version": "1.0.30001078",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001078.tgz",
@@ -4856,6 +4873,24 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
+    },
+    "decamelize-keys": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
+      "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
+      "dev": true,
+      "requires": {
+        "decamelize": "^1.1.0",
+        "map-obj": "^1.0.0"
+      },
+      "dependencies": {
+        "map-obj": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+          "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+          "dev": true
+        }
+      }
     },
     "decode-uri-component": {
       "version": "0.2.0",
@@ -5477,6 +5512,82 @@
           "dev": true
         }
       }
+    },
+    "eslint-formatter-pretty": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-formatter-pretty/-/eslint-formatter-pretty-4.0.0.tgz",
+      "integrity": "sha512-QgdeZxQwWcN0TcXXNZJiS6BizhAANFhCzkE7Yl9HKB7WjElzwED6+FbbZB2gji8ofgJTGPqKm6VRCNT3OGCeEw==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.1.0",
+        "eslint-rule-docs": "^1.1.5",
+        "log-symbols": "^4.0.0",
+        "plur": "^4.0.0",
+        "string-width": "^4.2.0",
+        "supports-hyperlinks": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "log-symbols": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
+          "integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "eslint-rule-docs": {
+      "version": "1.1.201",
+      "resolved": "https://registry.npmjs.org/eslint-rule-docs/-/eslint-rule-docs-1.1.201.tgz",
+      "integrity": "sha512-HS327MkM3ebCcjAQMkhNYZbN/4Eu/NO5ipDK8uNVPqUrAPRUsXkuuEfE+DEx4YItkszKp4ND1F3hN8BwfXdx0w==",
+      "dev": true
     },
     "eslint-scope": {
       "version": "5.1.0",
@@ -7154,6 +7265,12 @@
         }
       }
     },
+    "hard-rejection": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
+      "integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==",
+      "dev": true
+    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -7714,6 +7831,12 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.2.tgz",
       "integrity": "sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg==",
+      "dev": true
+    },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
       "dev": true
     },
     "is-plain-object": {
@@ -8678,6 +8801,12 @@
       "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
       "dev": true
     },
+    "map-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.1.0.tgz",
+      "integrity": "sha512-glc9y00wgtwcDmp7GaE/0b0OnxpNJsVf3ael/An6Fe2Q51LLwN1er6sdomLRzz5h0+yMpiYLhWYF5R7HeqVd4g==",
+      "dev": true
+    },
     "map-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
@@ -8780,6 +8909,41 @@
         }
       }
     },
+    "meow": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-7.0.1.tgz",
+      "integrity": "sha512-tBKIQqVrAHqwit0vfuFPY3LlzJYkEOFyKa3bPgxzNl6q/RtN8KQ+ALYEASYuFayzSAsjlhXj/JZ10rH85Q6TUw==",
+      "dev": true,
+      "requires": {
+        "@types/minimist": "^1.2.0",
+        "arrify": "^2.0.1",
+        "camelcase": "^6.0.0",
+        "camelcase-keys": "^6.2.2",
+        "decamelize-keys": "^1.1.0",
+        "hard-rejection": "^2.1.0",
+        "minimist-options": "^4.0.2",
+        "normalize-package-data": "^2.5.0",
+        "read-pkg-up": "^7.0.1",
+        "redent": "^3.0.0",
+        "trim-newlines": "^3.0.0",
+        "type-fest": "^0.13.1",
+        "yargs-parser": "^18.1.3"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.0.0.tgz",
+          "integrity": "sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w==",
+          "dev": true
+        },
+        "type-fest": {
+          "version": "0.13.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+          "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+          "dev": true
+        }
+      }
+    },
     "merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -8840,6 +9004,12 @@
       "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
       "dev": true
     },
+    "min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true
+    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -8854,6 +9024,31 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
+    },
+    "minimist-options": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
+      "integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
+      "dev": true,
+      "requires": {
+        "arrify": "^1.0.1",
+        "is-plain-obj": "^1.1.0",
+        "kind-of": "^6.0.3"
+      },
+      "dependencies": {
+        "arrify": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+          "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+          "dev": true
+        }
+      }
     },
     "minipass": {
       "version": "2.9.0",
@@ -10190,6 +10385,12 @@
         "escape-goat": "^2.0.0"
       }
     },
+    "quick-lru": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
+      "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
+      "dev": true
+    },
     "randomatic": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
@@ -10269,6 +10470,17 @@
           "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
           "dev": true
         }
+      }
+    },
+    "read-pkg-up": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+      "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+      "dev": true,
+      "requires": {
+        "find-up": "^4.1.0",
+        "read-pkg": "^5.2.0",
+        "type-fest": "^0.8.1"
       }
     },
     "readable-stream": {
@@ -10603,6 +10815,16 @@
       "dev": true,
       "requires": {
         "resolve": "^1.1.6"
+      }
+    },
+    "redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "requires": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
       }
     },
     "reduce-extract": {
@@ -11658,6 +11880,15 @@
         "is-utf8": "^0.2.1"
       }
     },
+    "strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "requires": {
+        "min-indent": "^1.0.0"
+      }
+    },
     "strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
@@ -11720,6 +11951,27 @@
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
           "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
           "dev": true
+        }
+      }
+    },
+    "supports-hyperlinks": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.1.0.tgz",
+      "integrity": "sha512-zoE5/e+dnEijk6ASB6/qrK+oYdm2do1hjoLWrqUC/8WEIW1gbxFcKuBof7sW8ArN6e+AYvsE8HBGiVRWL/F5CA==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^4.0.0",
+        "supports-color": "^7.0.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
         }
       }
     },
@@ -12000,11 +12252,39 @@
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
       "dev": true
     },
+    "trim-newlines": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.0.tgz",
+      "integrity": "sha512-C4+gOpvmxaSMKuEf9Qc134F1ZuOHVXKRbtEflf4NTtuuJDEIJ9p5PXsalL8SkeRw+qit1Mo+yuvMPAKwWg/1hA==",
+      "dev": true
+    },
     "trim-off-newlines": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz",
       "integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM=",
       "dev": true
+    },
+    "tsd": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/tsd/-/tsd-0.13.1.tgz",
+      "integrity": "sha512-+UYM8LRG/M4H8ISTg2ow8SWi65PS7Os+4DUnyiQLbJysXBp2DEmws9SMgBH+m8zHcJZqUJQ+mtDWJXP1IAvB2A==",
+      "dev": true,
+      "requires": {
+        "eslint-formatter-pretty": "^4.0.0",
+        "globby": "^11.0.1",
+        "meow": "^7.0.1",
+        "path-exists": "^4.0.0",
+        "read-pkg-up": "^7.0.0",
+        "update-notifier": "^4.1.0"
+      },
+      "dependencies": {
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        }
+      }
     },
     "tslib": {
       "version": "1.13.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "join-monster",
-  "version": "2.1.2",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -7114,9 +7114,9 @@
       "dev": true
     },
     "graphql": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.1.0.tgz",
-      "integrity": "sha512-0TVyfOlCGhv/DBczQkJmwXOK6fjWkjzY3Pt7wY8i0gcYXq8aogG3weCsg48m72lywKSeOqedEHvVPOvZvSD51Q==",
+      "version": "15.2.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.2.0.tgz",
+      "integrity": "sha512-tsceRyHfgzZo+ee0YK3o8f0CR0cXAXxRlxoORWFo/CoM1bVy3UXGWeyzBcf+Y6oqPvO27BDmOEVATcunOO/MrQ==",
       "dev": true
     },
     "graphql-relay": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7114,13 +7114,10 @@
       "dev": true
     },
     "graphql": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-0.13.2.tgz",
-      "integrity": "sha512-QZ5BL8ZO/B20VA8APauGBg3GyEgZ19eduvpLWoq5x7gMmWnHoy8rlQWPLmWgFvo1yNgjSEFMesmS4R6pPr7xog==",
-      "dev": true,
-      "requires": {
-        "iterall": "^1.2.1"
-      }
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.1.0.tgz",
+      "integrity": "sha512-0TVyfOlCGhv/DBczQkJmwXOK6fjWkjzY3Pt7wY8i0gcYXq8aogG3weCsg48m72lywKSeOqedEHvVPOvZvSD51Q==",
+      "dev": true
     },
     "graphql-relay": {
       "version": "0.6.0",
@@ -7991,12 +7988,6 @@
         "html-escaper": "^2.0.0",
         "istanbul-lib-report": "^3.0.0"
       }
-    },
-    "iterall": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
-      "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==",
-      "dev": true
     },
     "js-string-escape": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "testoracle-paging": "NODE_ENV=test DB=ORACLE PAGINATE=offset ava test/pagination/offset-paging.js && NODE_ENV=test DB=ORACLE PAGINATE=keyset ava test/pagination/keyset-paging.js",
     "testmysql": "NODE_ENV=test DB=MYSQL ava test/*.js",
     "testmysql-paging": "NODE_ENV=test DB=MYSQL PAGINATE=offset ava test/pagination/offset-paging.js && NODE_ENV=test DB=MYSQL PAGINATE=keyset ava test/pagination/keyset-paging.js",
+    "testtsd": "npm run build && tsd",
     "coverage": "nyc --reporter=html npm run test",
     "view-coverage": "open coverage/index.html",
     "lint": "eslint src test",
@@ -108,7 +109,8 @@
     "nyc": "^15.0.1",
     "pg": "^8.2.1",
     "sinon": "^9.0.2",
-    "sqlite3": "^4.2.0"
+    "sqlite3": "^4.2.0",
+    "tsd": "^0.13.1"
   },
   "dependencies": {
     "@stem/nesthydrationjs": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "join-monster",
-  "version": "2.1.2",
+  "version": "3.0.0",
   "description": "A GraphQL to SQL query execution layer for batch data fetching.",
   "main": "dist/index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   },
   "homepage": "https://github.com/join-monster/join-monster#readme",
   "peerDependencies": {
-    "graphql": "0.6 || 0.7 || 0.8 || 0.9 || 0.10 || 0.11 || 0.12 || 0.13"
+    "graphql": "15"
   },
   "devDependencies": {
     "@ava/babel": "^1.0.1",
@@ -93,7 +93,7 @@
     "eslint-config-airbnb-base": "^14.1.0",
     "eslint-config-prettier": "^6.11.0",
     "faker": "^4.1.0",
-    "graphql": "^0.13.0",
+    "graphql": "^15.1.0",
     "graphsiql": "0.2.0",
     "idx": "^2.5.6",
     "jsdoc-to-markdown": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   },
   "homepage": "https://github.com/join-monster/join-monster#readme",
   "peerDependencies": {
-    "graphql": "15"
+    "graphql": "^15.2.0"
   },
   "devDependencies": {
     "@ava/babel": "^1.0.1",
@@ -93,7 +93,7 @@
     "eslint-config-airbnb-base": "^14.1.0",
     "eslint-config-prettier": "^6.11.0",
     "faker": "^4.1.0",
-    "graphql": "^15.1.0",
+    "graphql": "^15.2.0",
     "graphsiql": "0.2.0",
     "idx": "^2.5.6",
     "jsdoc-to-markdown": "^5.0.0",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -34,9 +34,11 @@ export interface FieldConfigExtension<TSource, TContext, TArgs> {
   junction?: {
     include?: ThunkWithArgsCtx<
       {
-        sqlColumn?: string
-        sqlExpr?: string
-        sqlDeps?: string | string[]
+        [column: string]: {
+          sqlColumn?: string
+          sqlExpr?: string
+          sqlDeps?: string | string[]
+        }
       },
       TContext,
       TArgs
@@ -58,9 +60,9 @@ export interface FieldConfigExtension<TSource, TContext, TArgs> {
     sqlJoins?: [SqlJoin<TContext, TArgs>, SqlJoin<TContext, TArgs>]
     sqlTable: ThunkWithArgsCtx<string, TContext, TArgs>
     uniqueKey?: string | string[]
-    where?: Where<any, TArgs>
+    where?: Where<TContext, TArgs>
   }
-  limit?: ThunkWithArgsCtx<number, any, TContext>
+  limit?: ThunkWithArgsCtx<number, TContext, TArgs>
   orderBy?: ThunkWithArgsCtx<OrderBy, TContext, TArgs>
   sortKey?: ThunkWithArgsCtx<
     {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -3,109 +3,118 @@ export type Maybe<T> = null | undefined | T
 
 // Extend graphql objects and fields
 
-declare module 'graphql/type/definition' {
-  type SqlJoin<TContext, TArgs> = (
-    table1: string,
-    table2: string,
+export type SqlJoin<TContext, TArgs> = (
+  table1: string,
+  table2: string,
+  args: TArgs,
+  context: TContext,
+  sqlASTNode: any
+) => string
+export type Where<TContext, TArgs> = (
+  usersTable: string,
+  args: TArgs,
+  context: TContext,
+  sqlASTNode: any
+) => string | void
+export type Order = 'ASC' | 'asc' | 'DESC' | 'desc'
+export type OrderBy = string | { [key: string]: Order }
+export type ThunkWithArgsCtx<T, TContext, TArgs> =
+  | ((args: TArgs, context: TContext) => T)
+  | T
+
+export interface ObjectTypeExtension<TSource, TContext> {
+  alwaysFetch?: string
+  sqlTable?: ThunkWithArgsCtx<string, any, TContext>
+  uniqueKey?: string | string[]
+}
+
+export interface FieldConfigExtension<TSource, TContext, TArgs> {
+  ignoreAll?: boolean
+  ignoreTable?: boolean
+  junction?: {
+    include?: ThunkWithArgsCtx<
+      {
+        sqlColumn?: string
+        sqlExpr?: string
+        sqlDeps?: string | string[]
+      },
+      TContext,
+      TArgs
+    >
+    orderBy?: ThunkWithArgsCtx<OrderBy, TContext, TArgs>
+    sortKey?: ThunkWithArgsCtx<
+      {
+        order: Order
+        key: string | string[]
+      },
+      TContext,
+      TArgs
+    >
+    sqlBatch?: {
+      thisKey: string
+      parentKey: string
+      sqlJoin: SqlJoin<TContext, TArgs>
+    }
+    sqlJoins?: [SqlJoin<TContext, TArgs>, SqlJoin<TContext, TArgs>]
+    sqlTable: ThunkWithArgsCtx<string, TContext, TArgs>
+    uniqueKey?: string | string[]
+    where?: Where<any, TArgs>
+  }
+  limit?: ThunkWithArgsCtx<number, any, TContext>
+  orderBy?: ThunkWithArgsCtx<OrderBy, TContext, TArgs>
+  sortKey?: ThunkWithArgsCtx<
+    {
+      order: Order
+      key: string | string[]
+    },
+    TContext,
+    TArgs
+  >
+  sqlBatch?: {
+    thisKey: string
+    parentKey: string
+  }
+  sqlColumn?: string
+  sqlDeps?: string[]
+  sqlExpr?: (
+    table: string,
     args: TArgs,
     context: TContext,
     sqlASTNode: any
   ) => string
-  type Where<TContext, TArgs> = (
-    usersTable: string,
-    args: TArgs,
-    context: TContext,
-    sqlASTNode: any
-  ) => string | void
-  type Order = 'ASC' | 'asc' | 'DESC' | 'desc'
-  type OrderBy = string | { [key: string]: Order }
-  type ThunkWithArgsCtx<T, TContext, TArgs> =
-    | ((args: TArgs, context: TContext) => T)
-    | T
-
-  export interface GraphQLObjectTypeConfig<TSource, TContext> {
-    extensions?: Maybe<Readonly<Record<string, any>>> & {
-      alwaysFetch?: string
-      sqlTable?: ThunkWithArgsCtx<string, any, TContext>
-      uniqueKey?: string | string[]
-    }
-  }
-
-  export interface GraphQLFieldConfig<TSource, TContext, TArgs> {
-    extensions?: Maybe<Readonly<Record<string, any>>> & {
-      ignoreAll?: boolean
-      ignoreTable?: boolean
-      junction?: {
-        include?: ThunkWithArgsCtx<
-          {
-            sqlColumn?: string
-            sqlExpr?: string
-            sqlDeps?: string | string[]
-          },
-          TContext,
-          TArgs
-        >
-        orderBy?: ThunkWithArgsCtx<OrderBy, TContext, TArgs>
-        sortKey?: ThunkWithArgsCtx<
-          {
-            order: Order
-            key: string | string[]
-          },
-          TContext,
-          TArgs
-        >
-        sqlBatch?: {
-          thisKey: string
-          parentKey: string
-          sqlJoin: SqlJoin<TContext, TArgs>
-        }
-        sqlJoins?: [SqlJoin<TContext, TArgs>, SqlJoin<TContext, TArgs>]
-        sqlTable: ThunkWithArgsCtx<string, TContext, TArgs>
-        uniqueKey?: string | string[]
-        where?: Where<TContext, TArgs>
-      }
-      limit?: ThunkWithArgsCtx<number, any, TContext>
-      orderBy?: ThunkWithArgsCtx<OrderBy, TContext, TArgs>
-      sortKey?: ThunkWithArgsCtx<
-        {
-          order: Order
-          key: string | string[]
-        },
-        TContext,
-        TArgs
-      >
-      sqlBatch?: {
-        thisKey: string
-        parentKey: string
-      }
-      sqlColumn?: string
-      sqlDeps?: string[]
-      sqlExpr?: (
-        table: string,
-        args: TArgs,
-        context: TContext,
-        sqlASTNode: any
-      ) => string
-      sqlJoin?: SqlJoin<TContext, TArgs>
-      sqlPaginate?: boolean
-      where?: Where<TContext, TArgs>
-    }
-  }
+  sqlJoin?: SqlJoin<TContext, TArgs>
+  sqlPaginate?: boolean
+  where?: Where<TContext, TArgs>
 }
 
-export interface GraphQLUnionTypeConfig<TSource, TContext> {
-  extensions?: Maybe<Readonly<Record<string, any>>> & {
-    sqlTable?: string
-    uniqueKey?: string | string[]
-    alwaysFetch?: string
-  }
+export interface UnionTypeExtension {
+  sqlTable?: string
+  uniqueKey?: string | string[]
+  alwaysFetch?: string
 }
 
-export interface GraphQLInterfaceTypeConfig<TSource, TContext> {
-  extensions: Maybe<Readonly<Record<string, any>>> & {
-    sqlTable?: string
-    uniqueKey?: string | string[]
-    alwaysFetch?: string
+export interface InterfaceTypeExtension {
+  sqlTable?: string
+  uniqueKey?: string | string[]
+  alwaysFetch?: string
+}
+
+declare module 'graphql' {
+  interface GraphQLObjectTypeExtensions<TSource = any, TContext = any> {
+    joinMonster?: ObjectTypeExtension<TSource, TContext>
+  }
+  interface GraphQLFieldExtensions<
+    TSource,
+    TContext,
+    TArgs = { [argName: string]: any }
+  > {
+    joinMonster?: FieldConfigExtension<TSource, TContext, TArgs>
+  }
+  interface GraphQLUnionTypeExtensions {
+    joinMonster?: UnionTypeExtension
+  }
+  interface GraphQLInterfaceTypeExtensions {
+    joinMonster?: InterfaceTypeExtension
   }
 }
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,88 +1,139 @@
-
 import * as graphql from 'graphql'
+export type Maybe<T> = null | undefined | T
 
 // Extend graphql objects and fields
 
 declare module 'graphql/type/definition' {
-  type SqlJoin<TContext, TArgs> = (table1: string, table2: string, args: TArgs, context: TContext, sqlASTNode: any) => string
-  type Where<TContext, TArgs> = (usersTable: string, args: TArgs, context: TContext, sqlASTNode: any) => string | void
+  type SqlJoin<TContext, TArgs> = (
+    table1: string,
+    table2: string,
+    args: TArgs,
+    context: TContext,
+    sqlASTNode: any
+  ) => string
+  type Where<TContext, TArgs> = (
+    usersTable: string,
+    args: TArgs,
+    context: TContext,
+    sqlASTNode: any
+  ) => string | void
   type Order = 'ASC' | 'asc' | 'DESC' | 'desc'
   type OrderBy = string | { [key: string]: Order }
-  type ThunkWithArgsCtx<T, TContext, TArgs> = ((args: TArgs, context: TContext) => T) | T;
+  type ThunkWithArgsCtx<T, TContext, TArgs> =
+    | ((args: TArgs, context: TContext) => T)
+    | T
 
   export interface GraphQLObjectTypeConfig<TSource, TContext> {
-    alwaysFetch?: string
-    sqlTable?: ThunkWithArgsCtx<string, any, TContext>
-    uniqueKey?: string | string[]
+    extensions?: Maybe<Readonly<Record<string, any>>> & {
+      alwaysFetch?: string
+      sqlTable?: ThunkWithArgsCtx<string, any, TContext>
+      uniqueKey?: string | string[]
+    }
   }
 
   export interface GraphQLFieldConfig<TSource, TContext, TArgs> {
-    jmIgnoreAll?: boolean
-    jmIgnoreTable?: boolean
-    junction?: {
-      include?: ThunkWithArgsCtx<{
-        sqlColumn?: string
-        sqlExpr?: string
-        sqlDeps?: string | string[]
-      }, TContext, TArgs>
+    extensions?: Maybe<Readonly<Record<string, any>>> & {
+      ignoreAll?: boolean
+      ignoreTable?: boolean
+      junction?: {
+        include?: ThunkWithArgsCtx<
+          {
+            sqlColumn?: string
+            sqlExpr?: string
+            sqlDeps?: string | string[]
+          },
+          TContext,
+          TArgs
+        >
+        orderBy?: ThunkWithArgsCtx<OrderBy, TContext, TArgs>
+        sortKey?: ThunkWithArgsCtx<
+          {
+            order: Order
+            key: string | string[]
+          },
+          TContext,
+          TArgs
+        >
+        sqlBatch?: {
+          thisKey: string
+          parentKey: string
+          sqlJoin: SqlJoin<TContext, TArgs>
+        }
+        sqlJoins?: [SqlJoin<TContext, TArgs>, SqlJoin<TContext, TArgs>]
+        sqlTable: ThunkWithArgsCtx<string, TContext, TArgs>
+        uniqueKey?: string | string[]
+        where?: Where<TContext, TArgs>
+      }
+      limit?: ThunkWithArgsCtx<number, any, TContext>
       orderBy?: ThunkWithArgsCtx<OrderBy, TContext, TArgs>
-      sortKey?: ThunkWithArgsCtx<{
-        order: Order
-        key: string | string[]
-      }, TContext, TArgs>
+      sortKey?: ThunkWithArgsCtx<
+        {
+          order: Order
+          key: string | string[]
+        },
+        TContext,
+        TArgs
+      >
       sqlBatch?: {
         thisKey: string
         parentKey: string
-        sqlJoin: SqlJoin<TContext, TArgs>
       }
-      sqlJoins?: [SqlJoin<TContext, TArgs>, SqlJoin<TContext, TArgs>]
-      sqlTable: ThunkWithArgsCtx<string, TContext, TArgs>
-      uniqueKey?: string | string[]
+      sqlColumn?: string
+      sqlDeps?: string[]
+      sqlExpr?: (
+        table: string,
+        args: TArgs,
+        context: TContext,
+        sqlASTNode: any
+      ) => string
+      sqlJoin?: SqlJoin<TContext, TArgs>
+      sqlPaginate?: boolean
       where?: Where<TContext, TArgs>
     }
-    limit?: ThunkWithArgsCtx<number, any, TContext>
-    orderBy?: ThunkWithArgsCtx<OrderBy, TContext, TArgs>
-    sortKey?: ThunkWithArgsCtx<{
-      order: Order
-      key: string | string[]
-    }, TContext, TArgs>
-    sqlBatch?: {
-      thisKey: string
-      parentKey: string
-    }
-    sqlColumn?: string
-    sqlDeps?: string[]
-    sqlExpr?: (table: string, args: TArgs, context: TContext, sqlASTNode: any) => string
-    sqlJoin?: SqlJoin<TContext, TArgs>
-    sqlPaginate?: boolean
-    where?: Where<TContext, TArgs>
   }
 }
 
 export interface GraphQLUnionTypeConfig<TSource, TContext> {
-  sqlTable?: string
-  uniqueKey?: string | string[]
-  alwaysFetch?: string
+  extensions?: Maybe<Readonly<Record<string, any>>> & {
+    sqlTable?: string
+    uniqueKey?: string | string[]
+    alwaysFetch?: string
+  }
 }
 
 export interface GraphQLInterfaceTypeConfig<TSource, TContext> {
-  sqlTable?: string
-  uniqueKey?: string | string[]
-  alwaysFetch?: string
+  extensions: Maybe<Readonly<Record<string, any>>> & {
+    sqlTable?: string
+    uniqueKey?: string | string[]
+    alwaysFetch?: string
+  }
 }
 
 // JoinMonster lib interface
 
-interface DialectModule { name: string }
+interface DialectModule {
+  name: string
+}
 
 type Dialect = 'pg' | 'oracle' | 'mariadb' | 'mysql' | 'mysql8' | 'sqlite3'
-type JoinMonsterOptions = { minify?: boolean, dialect?: Dialect, dialectModule?: DialectModule }
+type JoinMonsterOptions = {
+  minify?: boolean
+  dialect?: Dialect
+  dialectModule?: DialectModule
+}
 
 type Rows = any
-type DbCallCallback = (sql:string, done: (err?: any, rows?: Rows) => void) => void
+type DbCallCallback = (
+  sql: string,
+  done: (err?: any, rows?: Rows) => void
+) => void
 type DbCallPromise = (sql: string) => Promise<Rows>
-type DbCall = DbCallCallback | DbCallPromise
 
-declare function joinMonster(resolveInfo: any, context: any, dbCall: DbCallCallback | DbCallPromise, options?: JoinMonsterOptions) : Promise<any>
+declare function joinMonster(
+  resolveInfo: any,
+  context: any,
+  dbCall: DbCallCallback | DbCallPromise,
+  options?: JoinMonsterOptions
+): Promise<any>
 
 export default joinMonster

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,12 @@ import * as queryAST from './query-ast-to-sql-ast'
 import arrToConnection from './array-to-connection'
 import AliasNamespace from './alias-namespace'
 import nextBatch from './batch-planner'
-import { buildWhereFunction, handleUserDbCall, compileSqlAST } from './util'
+import {
+  buildWhereFunction,
+  handleUserDbCall,
+  compileSqlAST,
+  getConfigFromSchemaObject
+} from './util'
 
 /*         _ _ _                _
   ___ __ _| | | |__   __ _  ___| | __
@@ -135,7 +140,7 @@ async function getNode(
   const type = resolveInfo.schema._typeMap[typeName]
   assert(type, `Type "${typeName}" not found in your schema.`)
   assert(
-    type._typeConfig.sqlTable,
+    getConfigFromSchemaObject(type).sqlTable,
     `joinMonster can't fetch a ${typeName} as a Node unless it has "sqlTable" tagged.`
   )
 
@@ -148,7 +153,12 @@ async function getNode(
       node: {
         type,
         name: type.name.toLowerCase(),
-        where
+        args: {},
+        extensions: {
+          joinMonster: {
+            where
+          }
+        }
       }
     }
   }

--- a/src/util.js
+++ b/src/util.js
@@ -1,5 +1,6 @@
 import util from 'util'
 import assert from 'assert'
+import idx from 'idx'
 import { nest } from '@stem/nesthydrationjs'
 import stringifySQL from './stringifiers/dispatcher'
 import resolveUnions from './resolve-unions'
@@ -49,6 +50,10 @@ export function unthunk(val, ...args) {
 export function validateSqlAST(topNode) {
   // TODO: this could be a bit more comprehensive
   assert(topNode.sqlJoin == null, 'root level field can not have "sqlJoin"')
+}
+
+export function getConfigFromSchemaObject(fieldOrType) {
+  return idx(fieldOrType, _ => _.extensions.joinMonster) || {}
 }
 
 export function objToCursor(obj) {
@@ -129,7 +134,7 @@ export function buildWhereFunction(type, condition, options) {
   const quote = ['mysql', 'mysql8', 'mariadb'].includes(name) ? '`' : '"'
 
   // determine the unique key so we know what to search by
-  const uniqueKey = type._typeConfig.uniqueKey
+  const uniqueKey = getConfigFromSchemaObject(type).uniqueKey
 
   // handle composite keys
   if (Array.isArray(uniqueKey)) {

--- a/test-api/schema-basic/Authored/Interface.js
+++ b/test-api/schema-basic/Authored/Interface.js
@@ -6,27 +6,31 @@ const { DB } = process.env
 
 export default new GraphQLInterfaceType({
   name: 'AuthoredInterface',
-  sqlTable: `(
-    SELECT
-      ${q('id', DB)},
-      ${q('body', DB)},
-      ${q('author_id', DB)},
-      NULL AS ${q('post_id', DB)},
-      ${q('created_at', DB)},
-      'Post' AS ${q('$type', DB)}
-    FROM ${q('posts', DB)}
-    UNION ALL
-    SELECT
-      ${q('id', DB)},
-      ${q('body', DB)},
-      ${q('author_id', DB)},
-      ${q('post_id', DB)},
-      ${q('created_at', DB)},
-      'Comment' AS ${q('$type', DB)}
-    FROM ${q('comments', DB)}
-  )`,
-  uniqueKey: ['id', '$type'],
-  alwaysFetch: '$type',
+  extensions: {
+    joinMonster: {
+      sqlTable: `(
+      SELECT
+        ${q('id', DB)},
+        ${q('body', DB)},
+        ${q('author_id', DB)},
+        NULL AS ${q('post_id', DB)},
+        ${q('created_at', DB)},
+        'Post' AS ${q('$type', DB)}
+      FROM ${q('posts', DB)}
+      UNION ALL
+      SELECT
+        ${q('id', DB)},
+        ${q('body', DB)},
+        ${q('author_id', DB)},
+        ${q('post_id', DB)},
+        ${q('created_at', DB)},
+        'Comment' AS ${q('$type', DB)}
+      FROM ${q('comments', DB)}
+    )`,
+      uniqueKey: ['id', '$type'],
+      alwaysFetch: '$type'
+    }
+  },
   fields: () => ({
     id: {
       type: GraphQLInt
@@ -36,7 +40,11 @@ export default new GraphQLInterfaceType({
     },
     authorId: {
       type: GraphQLInt,
-      sqlColumn: 'author_id'
+      extensions: {
+        joinMonster: {
+          sqlColumn: 'author_id'
+        }
+      }
     }
   }),
   resolveType: obj => obj.$type

--- a/test-api/schema-basic/Authored/Union.js
+++ b/test-api/schema-basic/Authored/Union.js
@@ -8,27 +8,31 @@ const { DB } = process.env
 
 export default new GraphQLUnionType({
   name: 'AuthoredUnion',
-  sqlTable: `(
-    SELECT
-      ${q('id', DB)},
-      ${q('body', DB)},
-      ${q('author_id', DB)},
-      NULL AS ${q('post_id', DB)},
-      ${q('created_at', DB)},
-      'Post' AS ${q('$type', DB)}
-    FROM ${q('posts', DB)}
-    UNION ALL
-    SELECT
-      ${q('id', DB)},
-      ${q('body', DB)},
-      ${q('author_id', DB)},
-      ${q('post_id', DB)},
-      ${q('created_at', DB)},
-      'Comment' AS ${q('$type', DB)}
-    FROM ${q('comments', DB)}
-  )`,
-  uniqueKey: ['id', '$type'],
+  extensions: {
+    joinMonster: {
+      sqlTable: `(
+      SELECT
+        ${q('id', DB)},
+        ${q('body', DB)},
+        ${q('author_id', DB)},
+        NULL AS ${q('post_id', DB)},
+        ${q('created_at', DB)},
+        'Post' AS ${q('$type', DB)}
+      FROM ${q('posts', DB)}
+      UNION ALL
+      SELECT
+        ${q('id', DB)},
+        ${q('body', DB)},
+        ${q('author_id', DB)},
+        ${q('post_id', DB)},
+        ${q('created_at', DB)},
+        'Comment' AS ${q('$type', DB)}
+      FROM ${q('comments', DB)}
+    )`,
+      uniqueKey: ['id', '$type'],
+      alwaysFetch: '$type'
+    }
+  },
   types: () => [Comment, Post],
-  alwaysFetch: '$type',
   resolveType: obj => obj.$type
 })

--- a/test-api/schema-basic/Comment.js
+++ b/test-api/schema-basic/Comment.js
@@ -16,8 +16,12 @@ const { STRATEGY, DB } = process.env
 export default new GraphQLObjectType({
   description: 'Comments on posts',
   name: 'Comment',
-  sqlTable: q('comments', DB),
-  uniqueKey: 'id',
+  extensions: {
+    joinMonster: {
+      sqlTable: q('comments', DB),
+      uniqueKey: 'id'
+    }
+  },
   interfaces: () => [Authored],
   fields: () => ({
     id: {
@@ -29,62 +33,85 @@ export default new GraphQLObjectType({
     },
     postId: {
       type: GraphQLInt,
-      sqlColumn: 'post_id'
+      extensions: {
+        joinMonster: {
+          sqlColumn: 'post_id'
+        }
+      }
     },
     post: {
       description: 'The post that the comment belongs to',
       type: Post,
-      ...(STRATEGY === 'batch'
-        ? {
-            sqlBatch: {
-              thisKey: 'id',
-              parentKey: 'post_id'
-            }
-          }
-        : {
-            sqlJoin: (commentTable, postTable) =>
-              `${commentTable}.${q('post_id', DB)} = ${postTable}.${q(
-                'id',
-                DB
-              )}`
-          })
+      extensions: {
+        joinMonster: {
+          ...(STRATEGY === 'batch'
+            ? {
+                sqlBatch: {
+                  thisKey: 'id',
+                  parentKey: 'post_id'
+                }
+              }
+            : {
+                sqlJoin: (commentTable, postTable) =>
+                  `${commentTable}.${q('post_id', DB)} = ${postTable}.${q(
+                    'id',
+                    DB
+                  )}`
+              })
+        }
+      }
     },
     authorId: {
       type: GraphQLInt,
-      sqlColumn: 'author_id'
+      extensions: {
+        joinMonster: {
+          sqlColumn: 'author_id'
+        }
+      }
     },
     author: {
       description: 'The user who wrote the comment',
       type: User,
-      ...(STRATEGY === 'batch'
-        ? {
-            sqlBatch: {
-              thisKey: 'id',
-              parentKey: 'author_id'
-            }
-          }
-        : {
-            sqlJoin: (commentTable, userTable) =>
-              `${commentTable}.${q('author_id', DB)} = ${userTable}.${q(
-                'id',
-                DB
-              )}`
-          })
+      extensions: {
+        joinMonster: {
+          ...(STRATEGY === 'batch'
+            ? {
+                sqlBatch: {
+                  thisKey: 'id',
+                  parentKey: 'author_id'
+                }
+              }
+            : {
+                sqlJoin: (commentTable, userTable) =>
+                  `${commentTable}.${q('author_id', DB)} = ${userTable}.${q(
+                    'id',
+                    DB
+                  )}`
+              })
+        }
+      }
     },
     likers: {
       description: 'Which users have liked this comment',
       type: new GraphQLList(User),
-      junction: {
-        sqlTable: q('likes', DB),
-        sqlJoins: [
-          (commentTable, likesTable) =>
-            `${commentTable}.${q('id', DB)} = ${likesTable}.${q(
-              'comment_id',
-              DB
-            )}`,
-          (likesTable, userTable) =>
-            `${likesTable}.${q('account_id', DB)} = ${userTable}.${q('id', DB)}`
-        ]
+      extensions: {
+        joinMonster: {
+          junction: {
+            sqlTable: q('likes', DB),
+            sqlJoins: [
+              (commentTable, likesTable) =>
+                `${commentTable}.${q('id', DB)} = ${likesTable}.${q(
+                  'comment_id',
+                  DB
+                )}`,
+              (likesTable, userTable) =>
+                `${likesTable}.${q('account_id', DB)} = ${userTable}.${q(
+                  'id',
+                  DB
+                )}`
+            ]
+          }
+        }
       }
     },
     archived: {
@@ -93,7 +120,11 @@ export default new GraphQLObjectType({
     createdAt: {
       description: 'When this was created',
       type: GraphQLString,
-      sqlColumn: 'created_at'
+      extensions: {
+        joinMonster: {
+          sqlColumn: 'created_at'
+        }
+      }
     }
   })
 })

--- a/test-api/schema-basic/Post.js
+++ b/test-api/schema-basic/Post.js
@@ -16,8 +16,12 @@ const { STRATEGY, DB } = process.env
 export default new GraphQLObjectType({
   description: 'A post from a user',
   name: 'Post',
-  sqlTable: q('posts', DB),
-  uniqueKey: 'id',
+  extensions: {
+    joinMonster: {
+      sqlTable: q('posts', DB),
+      uniqueKey: 'id'
+    }
+  },
   interfaces: () => [Authored],
   fields: () => ({
     id: {
@@ -29,22 +33,33 @@ export default new GraphQLObjectType({
     },
     authorId: {
       type: GraphQLInt,
-      sqlColumn: 'author_id'
+      extensions: {
+        joinMonster: {
+          sqlColumn: 'author_id'
+        }
+      }
     },
     author: {
       description: 'The user that created the post',
       type: User,
-      ...(STRATEGY === 'batch'
-        ? {
-            sqlBatch: {
-              thisKey: 'id',
-              parentKey: 'author_id'
-            }
-          }
-        : {
-            sqlJoin: (postTable, userTable) =>
-              `${postTable}.${q('author_id', DB)} = ${userTable}.${q('id', DB)}`
-          })
+      extensions: {
+        joinMonster: {
+          ...(STRATEGY === 'batch'
+            ? {
+                sqlBatch: {
+                  thisKey: 'id',
+                  parentKey: 'author_id'
+                }
+              }
+            : {
+                sqlJoin: (postTable, userTable) =>
+                  `${postTable}.${q('author_id', DB)} = ${userTable}.${q(
+                    'id',
+                    DB
+                  )}`
+              })
+        }
+      }
     },
     comments: {
       description: 'The comments on this post',
@@ -53,42 +68,50 @@ export default new GraphQLObjectType({
         active: { type: GraphQLBoolean },
         asc: { type: GraphQLBoolean }
       },
-      orderBy: args => ({ id: args.asc ? 'asc' : 'desc' }),
-      ...(['batch', 'mix'].includes(STRATEGY)
-        ? {
-            sqlBatch: {
-              thisKey: 'post_id',
-              parentKey: 'id'
-            },
-            where: (table, args) =>
-              args.active
-                ? `${table}.${q('archived', DB)} = ${bool(false, DB)}`
-                : null
-          }
-        : {
-            sqlJoin: (postTable, commentTable, args) =>
-              `${commentTable}.${q('post_id', DB)} = ${postTable}.${q(
-                'id',
-                DB
-              )} ${
-                args.active
-                  ? `AND ${commentTable}.${q('archived', DB)} = ${bool(
-                      false,
-                      DB
-                    )}`
-                  : ''
-              }`
-          })
+      extensions: {
+        joinMonster: {
+          orderBy: args => ({ id: args.asc ? 'asc' : 'desc' }),
+          ...(['batch', 'mix'].includes(STRATEGY)
+            ? {
+                sqlBatch: {
+                  thisKey: 'post_id',
+                  parentKey: 'id'
+                },
+                where: (table, args) =>
+                  args.active
+                    ? `${table}.${q('archived', DB)} = ${bool(false, DB)}`
+                    : null
+              }
+            : {
+                sqlJoin: (postTable, commentTable, args) =>
+                  `${commentTable}.${q('post_id', DB)} = ${postTable}.${q(
+                    'id',
+                    DB
+                  )} ${
+                    args.active
+                      ? `AND ${commentTable}.${q('archived', DB)} = ${bool(
+                          false,
+                          DB
+                        )}`
+                      : ''
+                  }`
+              })
+        }
+      }
     },
     numComments: {
       description: 'How many comments this post has',
       type: GraphQLInt,
-      // you can info from a correlated subquery
-      sqlExpr: table =>
-        `(SELECT count(*) from ${q('comments', DB)} WHERE ${table}.${q(
-          'id',
-          DB
-        )} = ${q('comments', DB)}.${q('post_id', DB)})`
+      extensions: {
+        joinMonster: {
+          // you can info from a correlated subquery
+          sqlExpr: table =>
+            `(SELECT count(*) from ${q('comments', DB)} WHERE ${table}.${q(
+              'id',
+              DB
+            )} = ${q('comments', DB)}.${q('post_id', DB)})`
+        }
+      }
     },
     archived: {
       type: GraphQLBoolean

--- a/test-api/schema-basic/QueryRoot.js
+++ b/test-api/schema-basic/QueryRoot.js
@@ -54,9 +54,13 @@ export default new GraphQLObjectType({
       args: {
         ids: { type: new GraphQLList(GraphQLInt) }
       },
-      where: (table, args) =>
-        args.ids ? `${table}.id IN (${args.ids.join(',')})` : null,
-      orderBy: 'id',
+      extensions: {
+        joinMonster: {
+          where: (table, args) =>
+            args.ids ? `${table}.id IN (${args.ids.join(',')})` : null,
+          orderBy: 'id'
+        }
+      },
       resolve: async (parent, args, context, resolveInfo) => {
         return joinMonster(
           resolveInfo,
@@ -82,15 +86,21 @@ export default new GraphQLObjectType({
           type: GraphQLInt
         }
       },
-      where: (usersTable, args, context) => {
-        // eslint-disable-line no-unused-vars
-        if (args.id) return `${usersTable}.${q('id', DB)} = ${args.id}`
-        if (args.idEncoded)
-          return `${usersTable}.${q('id', DB)} = ${fromBase64(args.idEncoded)}`
-        if (args.idAsync)
-          return Promise.resolve(
-            `${usersTable}.${q('id', DB)} = ${args.idAsync}`
-          )
+      extensions: {
+        joinMonster: {
+          where: (usersTable, args, context) => {
+            // eslint-disable-line no-unused-vars
+            if (args.id) return `${usersTable}.${q('id', DB)} = ${args.id}`
+            if (args.idEncoded)
+              return `${usersTable}.${q('id', DB)} = ${fromBase64(
+                args.idEncoded
+              )}`
+            if (args.idAsync)
+              return Promise.resolve(
+                `${usersTable}.${q('id', DB)} = ${args.idAsync}`
+              )
+          }
+        }
       },
       resolve: (parent, args, context, resolveInfo) => {
         return joinMonster(
@@ -109,10 +119,14 @@ export default new GraphQLObjectType({
           type: GraphQLBoolean
         }
       },
-      where: (sponsorsTable, args, context) => {
-        // eslint-disable-line no-unused-vars
-        if (args.filterLegless)
-          return `${sponsorsTable}.${q('num_legs', DB)} IS NULL`
+      extensions: {
+        joinMonster: {
+          where: (sponsorsTable, args, context) => {
+            // eslint-disable-line no-unused-vars
+            if (args.filterLegless)
+              return `${sponsorsTable}.${q('num_legs', DB)} IS NULL`
+          }
+        }
       },
       resolve: (parent, args, context, resolveInfo) => {
         // use the callback version this time

--- a/test-api/schema-basic/Sponsor.js
+++ b/test-api/schema-basic/Sponsor.js
@@ -8,21 +8,37 @@ const { DB } = process.env
 const Sponsor = new GraphQLObjectType({
   description: 'people who have given money',
   name: 'Sponsor',
-  sqlTable: q('sponsors', DB),
-  uniqueKey: ['generation', 'first_name', 'last_name'],
+  extensions: {
+    joinMonster: {
+      sqlTable: q('sponsors', DB),
+      uniqueKey: ['generation', 'first_name', 'last_name']
+    }
+  },
   interfaces: [Person],
   fields: () => ({
     firstName: {
       type: GraphQLString,
-      sqlColumn: 'first_name'
+      extensions: {
+        joinMonster: {
+          sqlColumn: 'first_name'
+        }
+      }
     },
     lastName: {
       type: GraphQLString,
-      sqlColumn: 'last_name'
+      extensions: {
+        joinMonster: {
+          sqlColumn: 'last_name'
+        }
+      }
     },
     fullName: {
       type: GraphQLString,
-      sqlDeps: ['first_name', 'last_name'],
+      extensions: {
+        joinMonster: {
+          sqlDeps: ['first_name', 'last_name']
+        }
+      },
       resolve: sponsor => `${sponsor.first_name} ${sponsor.last_name}`
     },
     generation: {
@@ -31,12 +47,20 @@ const Sponsor = new GraphQLObjectType({
     numLegs: {
       description: 'How many legs this user has',
       type: GraphQLInt,
-      sqlColumn: 'num_legs'
+      extensions: {
+        joinMonster: {
+          sqlColumn: 'num_legs'
+        }
+      }
     },
     numFeet: {
       description: 'How many feet this user has',
       type: GraphQLInt,
-      sqlDeps: ['num_legs'],
+      extensions: {
+        joinMonster: {
+          sqlDeps: ['num_legs']
+        }
+      },
       resolve: user => user.num_legs
     }
   })

--- a/test-api/schema-paginated/Authored/Interface.js
+++ b/test-api/schema-paginated/Authored/Interface.js
@@ -13,27 +13,31 @@ const { DB, PAGINATE } = process.env
 
 export const Authored = new GraphQLInterfaceType({
   name: 'AuthoredInterface',
-  sqlTable: `(
-    SELECT
-      ${q('id', DB)},
-      ${q('body', DB)},
-      ${q('author_id', DB)},
-      NULL AS ${q('post_id', DB)},
-      ${q('created_at', DB)},
-      'Post' AS ${q('$type', DB)}
-    FROM ${q('posts', DB)}
-    UNION ALL
-    SELECT
-      ${q('id', DB)},
-      ${q('body', DB)},
-      ${q('author_id', DB)},
-      ${q('post_id', DB)},
-      ${q('created_at', DB)},
-      'Comment' AS ${q('$type', DB)}
-    FROM ${q('comments', DB)}
-  )`,
-  uniqueKey: ['id', '$type'],
-  alwaysFetch: '$type',
+  extensions: {
+    joinMonster: {
+      sqlTable: `(
+      SELECT
+        ${q('id', DB)},
+        ${q('body', DB)},
+        ${q('author_id', DB)},
+        NULL AS ${q('post_id', DB)},
+        ${q('created_at', DB)},
+        'Post' AS ${q('$type', DB)}
+      FROM ${q('posts', DB)}
+      UNION ALL
+      SELECT
+        ${q('id', DB)},
+        ${q('body', DB)},
+        ${q('author_id', DB)},
+        ${q('post_id', DB)},
+        ${q('created_at', DB)},
+        'Comment' AS ${q('$type', DB)}
+      FROM ${q('comments', DB)}
+    )`,
+      uniqueKey: ['id', '$type'],
+      alwaysFetch: '$type'
+    }
+  },
   fields: () => ({
     id: {
       type: GraphQLID
@@ -43,7 +47,11 @@ export const Authored = new GraphQLInterfaceType({
     },
     authorId: {
       type: GraphQLInt,
-      sqlColumn: 'author_id'
+      extensions: {
+        joinMonster: {
+          sqlColumn: 'author_id'
+        }
+      }
     }
   }),
   resolveType: obj => obj.$type

--- a/test-api/schema-paginated/Authored/Union.js
+++ b/test-api/schema-paginated/Authored/Union.js
@@ -8,27 +8,31 @@ const { DB } = process.env
 
 export default new GraphQLUnionType({
   name: 'AuthoredUnion',
-  sqlTable: `(
-    SELECT
-      ${q('id', DB)},
-      ${q('body', DB)},
-      ${q('author_id', DB)},
-      NULL AS ${q('post_id', DB)},
-      ${q('created_at', DB)},
-      'Post' AS ${q('$type', DB)}
-    FROM ${q('posts', DB)}
-    UNION ALL
-    SELECT
-      ${q('id', DB)},
-      ${q('body', DB)},
-      ${q('author_id', DB)},
-      ${q('post_id', DB)},
-      ${q('created_at', DB)},
-      'Comment' AS ${q('$type', DB)}
-    FROM ${q('comments', DB)}
-  )`,
-  uniqueKey: ['id', '$type'],
+  extensions: {
+    joinMonster: {
+      sqlTable: `(
+      SELECT
+        ${q('id', DB)},
+        ${q('body', DB)},
+        ${q('author_id', DB)},
+        NULL AS ${q('post_id', DB)},
+        ${q('created_at', DB)},
+        'Post' AS ${q('$type', DB)}
+      FROM ${q('posts', DB)}
+      UNION ALL
+      SELECT
+        ${q('id', DB)},
+        ${q('body', DB)},
+        ${q('author_id', DB)},
+        ${q('post_id', DB)},
+        ${q('created_at', DB)},
+        'Comment' AS ${q('$type', DB)}
+      FROM ${q('comments', DB)}
+    )`,
+      uniqueKey: ['id', '$type'],
+      alwaysFetch: '$type'
+    }
+  },
   types: () => [Comment, Post],
-  alwaysFetch: '$type',
   resolveType: obj => obj.$type
 })

--- a/test-api/schema-paginated/Comment.js
+++ b/test-api/schema-paginated/Comment.js
@@ -19,13 +19,21 @@ const { PAGINATE, DB } = process.env
 export const Comment = new GraphQLObjectType({
   description: 'Comments on posts',
   name: 'Comment',
-  sqlTable: `(SELECT * FROM ${q('comments', DB)})`,
-  uniqueKey: 'id',
+  extensions: {
+    joinMonster: {
+      sqlTable: `(SELECT * FROM ${q('comments', DB)})`,
+      uniqueKey: 'id'
+    }
+  },
   interfaces: () => [nodeInterface, Authored],
   fields: () => ({
     id: {
       ...globalIdField(),
-      sqlDeps: ['id']
+      extensions: {
+        joinMonster: {
+          sqlDeps: ['id']
+        }
+      }
     },
     body: {
       description: 'The content of the comment',
@@ -34,18 +42,33 @@ export const Comment = new GraphQLObjectType({
     post: {
       description: 'The post that the comment belongs to',
       type: Post,
-      sqlJoin: (commentTable, postTable) =>
-        `${commentTable}.${q('post_id', DB)} = ${postTable}.${q('id', DB)}`
+      extensions: {
+        joinMonster: {
+          sqlJoin: (commentTable, postTable) =>
+            `${commentTable}.${q('post_id', DB)} = ${postTable}.${q('id', DB)}`
+        }
+      }
     },
     authorId: {
       type: GraphQLInt,
-      sqlColumn: 'author_id'
+      extensions: {
+        joinMonster: {
+          sqlColumn: 'author_id'
+        }
+      }
     },
     author: {
       description: 'The user who wrote the comment',
       type: User,
-      sqlJoin: (commentTable, userTable) =>
-        `${commentTable}.${q('author_id', DB)} = ${userTable}.${q('id', DB)}`
+      extensions: {
+        joinMonster: {
+          sqlJoin: (commentTable, userTable) =>
+            `${commentTable}.${q('author_id', DB)} = ${userTable}.${q(
+              'id',
+              DB
+            )}`
+        }
+      }
     },
     archived: {
       type: GraphQLBoolean
@@ -53,23 +76,34 @@ export const Comment = new GraphQLObjectType({
     likers: {
       description: 'Which users have liked this comment',
       type: new GraphQLList(User),
-      junction: {
-        sqlTable: 'likes',
-        sqlJoins: [
-          (commentTable, likesTable) =>
-            `${commentTable}.${q('id', DB)} = ${likesTable}.${q(
-              'comment_id',
-              DB
-            )}`,
-          (likesTable, userTable) =>
-            `${likesTable}.${q('account_id', DB)} = ${userTable}.${q('id', DB)}`
-        ]
+      extensions: {
+        joinMonster: {
+          junction: {
+            sqlTable: 'likes',
+            sqlJoins: [
+              (commentTable, likesTable) =>
+                `${commentTable}.${q('id', DB)} = ${likesTable}.${q(
+                  'comment_id',
+                  DB
+                )}`,
+              (likesTable, userTable) =>
+                `${likesTable}.${q('account_id', DB)} = ${userTable}.${q(
+                  'id',
+                  DB
+                )}`
+            ]
+          }
+        }
       }
     },
     createdAt: {
       description: 'When this was created',
       type: GraphQLString,
-      sqlColumn: 'created_at'
+      extensions: {
+        joinMonster: {
+          sqlColumn: 'created_at'
+        }
+      }
     }
   })
 })

--- a/test-api/schema-paginated/ContextPost.js
+++ b/test-api/schema-paginated/ContextPost.js
@@ -10,12 +10,20 @@ const ContextPost = new GraphQLObjectType({
     'A post from a user. This object is used in a context test and must be given a context.table to resolve.',
   name: 'ContextPost',
   interfaces: () => [nodeInterface],
-  sqlTable: (_, context) => `(SELECT * FROM ${q(context.table, DB)})`,
-  uniqueKey: 'id',
+  extensions: {
+    joinMonster: {
+      sqlTable: (_, context) => `(SELECT * FROM ${q(context.table, DB)})`,
+      uniqueKey: 'id'
+    }
+  },
   fields: () => ({
     id: {
       ...globalIdField(),
-      sqlDeps: ['id']
+      extensions: {
+        joinMonster: {
+          sqlDeps: ['id']
+        }
+      }
     },
     body: {
       description: 'The content of the post',

--- a/test-api/schema-paginated/Post.js
+++ b/test-api/schema-paginated/Post.js
@@ -24,13 +24,21 @@ const { PAGINATE, STRATEGY, DB } = process.env
 export const Post = new GraphQLObjectType({
   description: 'A post from a user',
   name: 'Post',
-  sqlTable: `(SELECT * FROM ${q('posts', DB)})`,
-  uniqueKey: 'id',
+  extensions: {
+    joinMonster: {
+      sqlTable: `(SELECT * FROM ${q('posts', DB)})`,
+      uniqueKey: 'id'
+    }
+  },
   interfaces: () => [nodeInterface, Authored],
   fields: () => ({
     id: {
       ...globalIdField(),
-      sqlDeps: ['id']
+      extensions: {
+        joinMonster: {
+          sqlDeps: ['id']
+        }
+      }
     },
     body: {
       description: 'The content of the post',
@@ -38,22 +46,33 @@ export const Post = new GraphQLObjectType({
     },
     authorId: {
       type: GraphQLInt,
-      sqlColumn: 'author_id'
+      extensions: {
+        joinMonster: {
+          sqlColumn: 'author_id'
+        }
+      }
     },
     author: {
       description: 'The user that created the post',
       type: User,
-      ...(STRATEGY === 'batch'
-        ? {
-            sqlBatch: {
-              thisKey: 'id',
-              parentKey: 'author_id'
-            }
-          }
-        : {
-            sqlJoin: (postTable, userTable) =>
-              `${postTable}.${q('author_id', DB)} = ${userTable}.${q('id', DB)}`
-          })
+      extensions: {
+        joinMonster: {
+          ...(STRATEGY === 'batch'
+            ? {
+                sqlBatch: {
+                  thisKey: 'id',
+                  parentKey: 'author_id'
+                }
+              }
+            : {
+                sqlJoin: (postTable, userTable) =>
+                  `${postTable}.${q('author_id', DB)} = ${userTable}.${q(
+                    'id',
+                    DB
+                  )}`
+              })
+        }
+      }
     },
     comments: {
       description: 'The comments on this post',
@@ -62,72 +81,86 @@ export const Post = new GraphQLObjectType({
         active: { type: GraphQLBoolean },
         ...(PAGINATE === 'offset' ? forwardConnectionArgs : connectionArgs)
       },
-      sqlPaginate: !!PAGINATE,
-      ...do {
-        if (PAGINATE === 'offset') {
-          ;({ orderBy: 'id' })
-        } else if (PAGINATE === 'keyset') {
-          ;({
-            sortKey: {
-              order: 'DESC',
-              key: 'id'
+      resolve: PAGINATE
+        ? undefined
+        : (post, args) => {
+            post.comments.sort((a, b) => a.id - b.id)
+            return connectionFromArray(post.comments, args)
+          },
+      extensions: {
+        joinMonster: {
+          sqlPaginate: !!PAGINATE,
+          ...do {
+            if (PAGINATE === 'offset') {
+              ;({ orderBy: 'id' })
+            } else if (PAGINATE === 'keyset') {
+              ;({
+                sortKey: {
+                  order: 'DESC',
+                  key: 'id'
+                }
+              })
+            } else {
+              {
+              }
             }
-          })
-        } else {
-          ;({
-            resolve: (user, args) => {
-              user.comments.sort((a, b) => a.id - b.id)
-              return connectionFromArray(user.comments, args)
+          },
+          ...do {
+            if (STRATEGY === 'batch' || STRATEGY === 'mix') {
+              ;({
+                sqlBatch: {
+                  thisKey: 'post_id',
+                  parentKey: 'id'
+                },
+                where: (table, args) =>
+                  args.active
+                    ? `${table}.${q('archived', DB)} = ${bool(false, DB)}`
+                    : null
+              })
+            } else {
+              ;({
+                sqlJoin: (postTable, commentTable, args) =>
+                  `${commentTable}.${q('post_id', DB)} = ${postTable}.${q(
+                    'id',
+                    DB
+                  )} ${
+                    args.active
+                      ? `AND ${commentTable}.${q('archived', DB)} = ${bool(
+                          false,
+                          DB
+                        )}`
+                      : ''
+                  }`
+              })
             }
-          })
-        }
-      },
-      ...do {
-        if (STRATEGY === 'batch' || STRATEGY === 'mix') {
-          ;({
-            sqlBatch: {
-              thisKey: 'post_id',
-              parentKey: 'id'
-            },
-            where: (table, args) =>
-              args.active
-                ? `${table}.${q('archived', DB)} = ${bool(false, DB)}`
-                : null
-          })
-        } else {
-          ;({
-            sqlJoin: (postTable, commentTable, args) =>
-              `${commentTable}.${q('post_id', DB)} = ${postTable}.${q(
-                'id',
-                DB
-              )} ${
-                args.active
-                  ? `AND ${commentTable}.${q('archived', DB)} = ${bool(
-                      false,
-                      DB
-                    )}`
-                  : ''
-              }`
-          })
+          }
         }
       }
     },
     numComments: {
       description: 'How many comments this post has',
       type: GraphQLInt,
-      // you can info from a correlated subquery
-      sqlExpr: table =>
-        `(SELECT count(*) from ${q('comments', DB)} WHERE ${table}.${q(
-          'id',
-          DB
-        )} = comments.${q('post_id', DB)})`
+      extensions: {
+        joinMonster: {
+          // you can info from a correlated subquery
+          sqlExpr: table =>
+            `(SELECT count(*) from ${q('comments', DB)} WHERE ${table}.${q(
+              'id',
+              DB
+            )} = comments.${q('post_id', DB)})`
+        }
+      }
     },
     archived: {
       type: GraphQLBoolean
     },
     createdAt: {
       type: GraphQLString,
-      sqlColumn: 'created_at'
+      extensions: {
+        joinMonster: {
+          sqlColumn: 'created_at'
+        }
+      }
     }
   })
 })

--- a/test-api/schema-paginated/Sponsor.js
+++ b/test-api/schema-paginated/Sponsor.js
@@ -3,16 +3,28 @@ import { GraphQLObjectType, GraphQLString, GraphQLInt } from 'graphql'
 const Sponsor = new GraphQLObjectType({
   description: 'people who have given money',
   name: 'Sponsor',
-  sqlTable: '"sponsors"',
-  uniqueKey: ['generation', 'first_name', 'last_name'],
+  extensions: {
+    joinMonster: {
+      sqlTable: '"sponsors"',
+      uniqueKey: ['generation', 'first_name', 'last_name']
+    }
+  },
   fields: () => ({
     firstName: {
       type: GraphQLString,
-      sqlColumn: 'first_name'
+      extensions: {
+        joinMonster: {
+          sqlColumn: 'first_name'
+        }
+      }
     },
     lastName: {
       type: GraphQLString,
-      sqlColumn: 'last_name'
+      extensions: {
+        joinMonster: {
+          sqlColumn: 'last_name'
+        }
+      }
     },
     generation: {
       type: GraphQLInt
@@ -20,13 +32,21 @@ const Sponsor = new GraphQLObjectType({
     numLegs: {
       description: 'How many legs this user has',
       type: GraphQLInt,
-      sqlColumn: 'num_legs'
+      extensions: {
+        joinMonster: {
+          sqlColumn: 'num_legs'
+        }
+      }
     },
     numFeet: {
       description: 'How many feet this user has',
       type: GraphQLInt,
-      sqlDeps: ['num_legs'],
-      resolve: user => user.num_legs
+      extensions: {
+        joinMonster: {
+          sqlDeps: ['num_legs']
+        },
+        resolve: user => user.num_legs
+      }
     }
   })
 })

--- a/test-d/index.test-d.ts
+++ b/test-d/index.test-d.ts
@@ -1,0 +1,218 @@
+import { expectType } from 'tsd'
+import joinMonster from '..'
+import { GraphQLObjectType, GraphQLList } from 'graphql'
+
+type ExampleContext = {
+  foo: 'bar'
+}
+type ExampleArgs = { [key: string]: any }
+
+// test table level extensions
+const User = new GraphQLObjectType({
+  name: 'User',
+  extensions: {
+    joinMonster: {
+      sqlTable: 'accounts',
+      uniqueKey: 'id',
+      alwaysFetch: 'createdAt'
+    }
+  },
+  fields: {}
+})
+
+// test field extensions
+new GraphQLObjectType<any, ExampleContext>({
+  name: 'User',
+  fields: () => ({
+    following: {
+      type: new GraphQLList(User),
+      extensions: {
+        joinMonster: {
+          ignoreAll: true,
+          ignoreTable: true,
+          limit: 10,
+          orderBy: {
+            foo: 'ASC',
+            bar: 'DESC'
+          },
+          sortKey: {
+            order: 'ASC',
+            key: ['id']
+          },
+          sqlBatch: {
+            thisKey: 'foo',
+            parentKey: 'bar'
+          },
+          sqlColumn: 'foo',
+          sqlDeps: ['bar', 'baz'],
+          sqlExpr: (table, args, context) => {
+            expectType<string>(table)
+            expectType<ExampleArgs>(args)
+            expectType<ExampleContext>(context)
+            return 'expr'
+          },
+          sqlJoin: (table1, table2, args, context) => {
+            expectType<string>(table1)
+            expectType<string>(table2)
+            expectType<ExampleArgs>(args)
+            expectType<ExampleContext>(context)
+            return 'foo'
+          },
+          sqlPaginate: true,
+          where: (table, args, context) => {
+            expectType<string>(table)
+            expectType<ExampleArgs>(args)
+            expectType<ExampleContext>(context)
+            return `${table}.is_active = TRUE`
+          }
+        }
+      }
+    }
+  })
+})
+
+// test thunked field extensions
+new GraphQLObjectType<any, ExampleContext>({
+  name: 'User',
+  fields: () => ({
+    following: {
+      type: new GraphQLList(User),
+      extensions: {
+        joinMonster: {
+          limit: (args, context) => {
+            expectType<ExampleArgs>(args)
+            expectType<ExampleContext>(context)
+            return 10
+          },
+          orderBy: (args, context) => {
+            expectType<ExampleArgs>(args)
+            expectType<ExampleContext>(context)
+            return {
+              foo: 'ASC',
+              bar: 'DESC'
+            }
+          },
+          sortKey: (args, context) => {
+            expectType<ExampleArgs>(args)
+            expectType<ExampleContext>(context)
+            return {
+              order: 'ASC',
+              key: ['id']
+            }
+          }
+        }
+      }
+    }
+  })
+})
+
+// test junction includes
+new GraphQLObjectType<any, ExampleContext>({
+  name: 'User',
+  fields: () => ({
+    following: {
+      type: new GraphQLList(User),
+      extensions: {
+        joinMonster: {
+          where: accountTable => `${accountTable}.is_active = TRUE`,
+          junction: {
+            sqlTable: 'relationships',
+            orderBy: {
+              foo: 'ASC',
+              bar: 'DESC'
+            },
+            sortKey: {
+              order: 'ASC',
+              key: ['id']
+            },
+            sqlBatch: {
+              thisKey: 'foo',
+              parentKey: 'bar',
+              sqlJoin: (table1, table2, args, context) => {
+                expectType<string>(table1)
+                expectType<string>(table2)
+
+                return 'foo'
+              }
+            },
+            include: {
+              closeness: {
+                sqlColumn: 'closeness'
+              }
+            },
+            sqlJoins: [
+              (followerTable, junctionTable, args, context) => {
+                expectType<string>(followerTable)
+                expectType<string>(junctionTable)
+                expectType<ExampleArgs>(args)
+                expectType<ExampleContext>(context)
+                return `${followerTable}.id = ${junctionTable}.follower_id`
+              },
+              (junctionTable, followeeTable, args, context) => {
+                expectType<string>(followeeTable)
+                expectType<string>(junctionTable)
+                expectType<ExampleArgs>(args)
+                expectType<ExampleContext>(context)
+                return `${junctionTable}.followee_id = ${followeeTable}.id`
+              }
+            ]
+          }
+        }
+      }
+    }
+  })
+})
+
+// test thunked junction includes
+new GraphQLObjectType<any, ExampleContext>({
+  name: 'User',
+  fields: () => ({
+    following: {
+      type: new GraphQLList(User),
+      extensions: {
+        joinMonster: {
+          where: accountTable => `${accountTable}.is_active = TRUE`,
+          junction: {
+            sqlTable: (args, context) => {
+              expectType<ExampleArgs>(args)
+              expectType<ExampleContext>(context)
+              return 'relationships'
+            },
+            orderBy: (args, context) => {
+              expectType<ExampleArgs>(args)
+              expectType<ExampleContext>(context)
+              return {
+                foo: 'ASC',
+                bar: 'DESC'
+              }
+            },
+            sortKey: (args, context) => {
+              expectType<ExampleArgs>(args)
+              expectType<ExampleContext>(context)
+              return {
+                order: 'ASC',
+                key: ['id']
+              }
+            },
+            include: (args, context) => {
+              expectType<ExampleArgs>(args)
+              expectType<ExampleContext>(context)
+
+              return {
+                closeness: {
+                  sqlColumn: 'closeness'
+                }
+              }
+            },
+            where: (junctionTable, args, context) => {
+              expectType<string>(junctionTable)
+              expectType<ExampleArgs>(args)
+              expectType<ExampleContext>(context)
+              return `${junctionTable}.follower_id <> ${junctionTable}.followee_id`
+            }
+          }
+        }
+      }
+    }
+  })
+})


### PR DESCRIPTION
This implements the new way that GraphQL asks user land code to decorate the schema: the `extensions` property of types and field configs. `graphql-js` as of v14 no longer supports being able to decorate the actual `GraphQLObjectType` or field objects with arbitrary properties because extra properties from the config objects passed to the constructors aren't assigned to the resulting instance. Instead, they accept an `extensions` option that does make it through and can contain whatever we like.

So, join-monster's non-standard properties should go in `extensions` I think! That way, we can rely on the `graphql-js` contract of them coming along instead of join-monster breaking as `graphql-js` changes it's private implementation. Config would come in like `extensions: { sqlTable: ... }}` instead of `{ sqlTable: ... }`, and then be accessed via `field.extensions.sqlTable` instead of `field.sqlTable`.

This change would fix things like #352,  without needing workarounds.

The big issue with this is that it's a big breaking change for users of `join-monster`: they need to update their schemas to use `extensions: { sqlTable: ... }}` instead of `{ sqlTable: ... }`. This PR implements the code change but not the docs change because I wanted to get some feedback before fully committing to that. Do y'all think that a breaking change and a major version bump is alright? If you want to use `graphql` > 14, you should bump to `join-monster` 3.0 , or do we need to support backwards compatibility for all graphql versions? I think the extensions API is a lot cleaner and should be recommended for sure and I think lowering the maintenance burden for this open source project by just saying "if you want to use new graphqls you need to use new join-monsters" and not having to support all of them simultaneously, but that's not really my call to make.