### PR TITLE
Multiple, independent, and ordered sortKey and orderBy directions

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,30 @@
 ### v3.0.0 (unreleased)
 
+**New features:**
+
+- Add support for explicit `orderBy` column orderings by passing an array of `{ column, direction }` objects. Useful for dynamically generating `orderBy`s without relying on object insertion order. Example:
+
+```javascript
+const User = new GraphQLObjectType({
+  fields: () => ({
+    comments: {
+      type: new GraphQLList(Comment),
+      extensions: {
+        joinMonster: {
+          // order these alphabetically, then by "id" if the comment body is the same
+          orderBy: [
+            { column: 'body', direction: 'asc' },
+            { column: 'id', direction: 'desc' }
+          ],
+          sqlJoin: (userTable, commentTable, args) =>
+            `${userTable}.id = ${commentTable}.author_id`
+        }
+      }
+    }
+  })
+})
+```
+
 **Breaking changes:**
 
 - Update GraphQL requirement to version 15, which supports a new `extensions` property where join-monster config lives. The config keys and values are largely unchanged, but now they must be nested under an `extensions: { joinMonster: ... }}` property on the GraphQLObjectTypes and fields using join-monster. To upgrade, you must move any non-standard keys off of your `GraphQLObjectType`s or field configs into the `extensions` of the same field. So, something like this:

--- a/docs/pagination.md
+++ b/docs/pagination.md
@@ -158,10 +158,10 @@ const User = new GraphQLObjectType({
           sqlPaginate: true,
           // orders on both `created_at` and `id`. the first property is the primary sort column.
           // it only sorts on `id` if `created_at` is equivalent
-          orderBy: {
-            created_at: 'desc',
-            id: 'asc'
-          },
+          orderBy: [
+            { column: 'created_at', direction: 'desc' },
+            { column: 'id', direction: 'asc' }
+          ],
           sqlJoin: (userTable, commentTable) =>
             `${userTable}.id = ${commentTable}.author_id`
         }

--- a/src/array-to-connection.js
+++ b/src/array-to-connection.js
@@ -1,5 +1,5 @@
 import { connectionFromArraySlice, cursorToOffset } from 'graphql-relay'
-import { objToCursor, wrap, last } from './util'
+import { objToCursor, last, sortKeyColumns } from './util'
 import idx from 'idx'
 
 // a function for data manipulation AFTER its nested.
@@ -69,8 +69,7 @@ function arrToConnection(data, sqlAST) {
       const sortKey = sqlAST.sortKey || sqlAST.junction.sortKey
       const edges = data.map(obj => {
         const cursor = {}
-        const key = sortKey.key
-        for (let column of wrap(key)) {
+        for (let column of sortKeyColumns(sortKey)) {
           cursor[column] = obj[column]
         }
         return { cursor: objToCursor(cursor), node: obj }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -16,8 +16,11 @@ export type Where<TContext, TArgs> = (
   context: TContext,
   sqlASTNode: any
 ) => string | void
-export type Order = 'ASC' | 'asc' | 'DESC' | 'desc'
-export type OrderBy = string | { [key: string]: Order }
+export type Direction = 'ASC' | 'asc' | 'DESC' | 'desc'
+export type OrderBy =
+  | string
+  | { [key: string]: Direction }
+  | { column: string; direction: Direction }[]
 export type ThunkWithArgsCtx<T, TContext, TArgs> =
   | ((args: TArgs, context: TContext) => T)
   | T
@@ -46,7 +49,7 @@ export interface FieldConfigExtension<TSource, TContext, TArgs> {
     orderBy?: ThunkWithArgsCtx<OrderBy, TContext, TArgs>
     sortKey?: ThunkWithArgsCtx<
       {
-        order: Order
+        order: Direction
         key: string | string[]
       },
       TContext,
@@ -66,7 +69,7 @@ export interface FieldConfigExtension<TSource, TContext, TArgs> {
   orderBy?: ThunkWithArgsCtx<OrderBy, TContext, TArgs>
   sortKey?: ThunkWithArgsCtx<
     {
-      order: Order
+      order: Direction
       key: string | string[]
     },
     TContext,

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -16,11 +16,21 @@ export type Where<TContext, TArgs> = (
   context: TContext,
   sqlASTNode: any
 ) => string | void
+
 export type Direction = 'ASC' | 'asc' | 'DESC' | 'desc'
+
 export type OrderBy =
   | string
-  | { [key: string]: Direction }
   | { column: string; direction: Direction }[]
+  | { [key: string]: Direction }
+
+export type SortKey =
+  | { column: string; direction: Direction }[]
+  | {
+      order: Direction
+      key: string | string[]
+    } // this is the old, pre 3.0 style limited to one direction for many keys
+
 export type ThunkWithArgsCtx<T, TContext, TArgs> =
   | ((args: TArgs, context: TContext) => T)
   | T
@@ -47,14 +57,7 @@ export interface FieldConfigExtension<TSource, TContext, TArgs> {
       TArgs
     >
     orderBy?: ThunkWithArgsCtx<OrderBy, TContext, TArgs>
-    sortKey?: ThunkWithArgsCtx<
-      {
-        order: Direction
-        key: string | string[]
-      },
-      TContext,
-      TArgs
-    >
+    sortKey?: ThunkWithArgsCtx<SortKey, TContext, TArgs>
     sqlBatch?: {
       thisKey: string
       parentKey: string
@@ -67,14 +70,7 @@ export interface FieldConfigExtension<TSource, TContext, TArgs> {
   }
   limit?: ThunkWithArgsCtx<number, TContext, TArgs>
   orderBy?: ThunkWithArgsCtx<OrderBy, TContext, TArgs>
-  sortKey?: ThunkWithArgsCtx<
-    {
-      order: Direction
-      key: string | string[]
-    },
-    TContext,
-    TArgs
-  >
+  sortKey?: ThunkWithArgsCtx<SortKey, TContext, TArgs>
   sqlBatch?: {
     thisKey: string
     parentKey: string

--- a/src/query-ast-to-sql-ast/index.js
+++ b/src/query-ast-to-sql-ast/index.js
@@ -10,7 +10,8 @@ import {
   ensure,
   unthunk,
   inspect,
-  getConfigFromSchemaObject
+  getConfigFromSchemaObject,
+  sortKeyColumns
 } from '../util'
 
 class SQLASTNode {
@@ -709,9 +710,9 @@ function keyToASTChild(key, namespace) {
 function handleColumnsRequiredForPagination(sqlASTNode, namespace) {
   if (sqlASTNode.sortKey || idx(sqlASTNode, _ => _.junction.sortKey)) {
     const sortKey = sqlASTNode.sortKey || sqlASTNode.junction.sortKey
-    assert(sortKey.order, '"sortKey" must have "order"')
+
     // this type of paging uses the "sort key(s)". we need to get this in order to generate the cursor
-    for (let column of wrap(ensure(sortKey, 'key'))) {
+    for (let column of sortKeyColumns(sortKey)) {
       const newChild = columnToASTChild(column, namespace)
       // if this joining on a "through-table", the sort key is on the threw table instead of this node's parent table
       if (!sqlASTNode.sortKey) {

--- a/src/query-ast-to-sql-ast/index.js
+++ b/src/query-ast-to-sql-ast/index.js
@@ -895,21 +895,44 @@ function spreadFragments(selections, fragments, typeName) {
   })
 }
 
+const validateAndNormalizeDirection = direction => {
+  direction = direction.toUpperCase()
+  if (direction !== 'ASC' && direction !== 'DESC') {
+    throw new Error(direction + ' is not a valid sorting direction')
+  }
+  return direction
+}
+
+// Normalize the three styles of orderBy to an array of {column, direction} objects.
+// orderBy could be just a string, interpreted as a column name, or an object of column: direction key values, or an array of { column, direction }s already.
 export function handleOrderBy(orderBy) {
   if (!orderBy) return undefined
-  const orderColumns = {}
-  if (typeof orderBy === 'object') {
+  const orderings = []
+  if (Array.isArray(orderBy)) {
+    for (const ordering of orderBy) {
+      assert(
+        ordering.column,
+        "'column' property must be defined on an ordering in an array"
+      )
+      orderings.push({
+        column: ordering.column,
+        direction: validateAndNormalizeDirection(ordering.direction)
+      })
+    }
+  } else if (typeof orderBy === 'object') {
     for (let column in orderBy) {
-      let direction = orderBy[column].toUpperCase()
-      if (direction !== 'ASC' && direction !== 'DESC') {
-        throw new Error(direction + ' is not a valid sorting direction')
-      }
-      orderColumns[column] = direction
+      orderings.push({
+        column,
+        direction: validateAndNormalizeDirection(orderBy[column])
+      })
     }
   } else if (typeof orderBy === 'string') {
-    orderColumns[orderBy] = 'ASC'
+    orderings.push({
+      column: orderBy,
+      direction: 'ASC'
+    })
   } else {
     throw new Error('"orderBy" is invalid type: ' + inspect(orderBy))
   }
-  return orderColumns
+  return orderings
 }

--- a/src/stringifiers/dialects/mariadb.js
+++ b/src/stringifiers/dialects/mariadb.js
@@ -3,7 +3,7 @@ import {
   offsetPagingSelect,
   interpretForOffsetPaging,
   interpretForKeysetPaging,
-  orderColumnsToString
+  orderingsToString
 } from '../shared'
 
 import { filter } from 'lodash'
@@ -39,7 +39,7 @@ function paginatedSelect(
       : ''
   }
   WHERE ${whereConditions}
-  ORDER BY ${orderColumnsToString(order.columns, quote, order.table)}
+  ORDER BY ${orderingsToString(order.columns, quote, order.table)}
   LIMIT ${limit}${offset ? ' OFFSET ' + offset : ''})`
 }
 

--- a/src/stringifiers/dialects/oracle.js
+++ b/src/stringifiers/dialects/oracle.js
@@ -1,7 +1,7 @@
 import {
   interpretForOffsetPaging,
   interpretForKeysetPaging,
-  orderColumnsToString
+  orderingsToString
 } from '../shared'
 import { filter } from 'lodash'
 
@@ -36,7 +36,7 @@ ${joinType === 'LEFT' ? 'OUTER' : 'CROSS'} APPLY (
       : ''
   }
   WHERE ${whereCondition}
-  ORDER BY ${orderColumnsToString(order.columns, q, order.table)}
+  ORDER BY ${orderingsToString(order.columns, q, order.table)}
   FETCH FIRST ${limit} ROWS ONLY
 ) ${q(as)}`
   }
@@ -45,7 +45,7 @@ FROM (
   SELECT "${as}".*
   FROM ${table} "${as}"
   WHERE ${whereCondition}
-  ORDER BY ${orderColumnsToString(order.columns, q, order.table)}
+  ORDER BY ${orderingsToString(order.columns, q, order.table)}
   FETCH FIRST ${limit} ROWS ONLY
 ) ${q(as)}`
 }
@@ -73,7 +73,7 @@ ${joinType === 'LEFT' ? 'OUTER' : 'CROSS'} APPLY (
       : ''
   }
   WHERE ${whereCondition}
-  ORDER BY ${orderColumnsToString(order.columns, q, order.table)}
+  ORDER BY ${orderingsToString(order.columns, q, order.table)}
   OFFSET ${offset} ROWS FETCH NEXT ${limit} ROWS ONLY
 ) ${q(as)}`
   }
@@ -82,7 +82,7 @@ FROM (
   SELECT "${as}".*, count(*) OVER () AS ${q('$total')}
   FROM ${table} "${as}"
   WHERE ${whereCondition}
-  ORDER BY ${orderColumnsToString(order.columns, q, order.table)}
+  ORDER BY ${orderingsToString(order.columns, q, order.table)}
   OFFSET ${offset} ROWS FETCH NEXT ${limit} ROWS ONLY
 ) ${q(as)}`
 }

--- a/src/stringifiers/dispatcher.js
+++ b/src/stringifiers/dispatcher.js
@@ -435,10 +435,11 @@ async function handleTable(
 // ordering inner(sub) queries DOES NOT guarantee the order of those results in the outer query
 function stringifyOuterOrder(orders, q) {
   const conditions = []
-  for (let condition of orders) {
-    for (let column in condition.columns) {
-      const direction = condition.columns[column]
-      conditions.push(`${q(condition.table)}.${q(column)} ${direction}`)
+  for (const condition of orders) {
+    for (const ordering of condition.columns) {
+      conditions.push(
+        `${q(condition.table)}.${q(ordering.column)} ${ordering.direction}`
+      )
     }
   }
   return conditions.join(', ')
@@ -449,9 +450,9 @@ function sortKeyToOrderColumns(sortKey, args) {
   if (args && args.last) {
     descending = !descending
   }
-  const orderColumns = {}
+  const orderings = []
   for (let column of wrap(sortKey.key)) {
-    orderColumns[column] = descending ? 'DESC' : 'ASC'
+    orderings.push({ column, direction: descending ? 'DESC' : 'ASC' })
   }
-  return orderColumns
+  return orderings
 }

--- a/src/stringifiers/dispatcher.js
+++ b/src/stringifiers/dispatcher.js
@@ -2,10 +2,11 @@ import assert from 'assert'
 import { filter } from 'lodash'
 import idx from 'idx'
 
-import { validateSqlAST, inspect, wrap } from '../util'
+import { validateSqlAST, inspect } from '../util'
 import {
   joinPrefix,
   thisIsNotTheEndOfThisBatch,
+  sortKeyToOrderings,
   whereConditionIsntSupposedToGoInsideSubqueryOrOnNextBatch
 } from './shared'
 
@@ -242,13 +243,13 @@ async function handleTable(
     if (idx(node, _ => _.junction.sortKey)) {
       orders.push({
         table: node.junction.as,
-        columns: sortKeyToOrderColumns(node.junction.sortKey, node.args)
+        columns: sortKeyToOrderings(node.junction.sortKey, node.args)
       })
     }
     if (node.sortKey) {
       orders.push({
         table: node.as,
-        columns: sortKeyToOrderColumns(node.sortKey, node.args)
+        columns: sortKeyToOrderings(node.sortKey, node.args)
       })
     }
   }
@@ -443,16 +444,4 @@ function stringifyOuterOrder(orders, q) {
     }
   }
   return conditions.join(', ')
-}
-
-function sortKeyToOrderColumns(sortKey, args) {
-  let descending = sortKey.order.toUpperCase() === 'DESC'
-  if (args && args.last) {
-    descending = !descending
-  }
-  const orderings = []
-  for (let column of wrap(sortKey.key)) {
-    orderings.push({ column, direction: descending ? 'DESC' : 'ASC' })
-  }
-  return orderings
 }

--- a/src/util.js
+++ b/src/util.js
@@ -246,3 +246,18 @@ export async function compileSqlAST(sqlAST, context, options) {
   }
   return { sql, shapeDefinition }
 }
+
+// Normalize the two different sortKey styles into one list of strings representing all the columns that will be sorted on
+export function sortKeyColumns(sortKey) {
+  return Array.isArray(sortKey)
+    ? sortKey.map(sort => {
+        assert(
+          sort.column,
+          `Each sortKey entry in an array must have a 'column' property, got ${JSON.stringify(
+            sortKey
+          )} instead`
+        )
+        return sort.column
+      })
+    : wrap(sortKey.key)
+}

--- a/test-api/schema-paginated/User.js
+++ b/test-api/schema-paginated/User.js
@@ -175,11 +175,11 @@ const User = new GraphQLObjectType({
               })
             } else if (PAGINATE === 'keyset') {
               ;({
-                sortKey: args => ({
+                sortKey: args => [
                   // eslint-disable-line no-unused-vars
-                  order: 'desc',
-                  key: ['created_at', 'id']
-                })
+                  { direction: 'desc', column: 'created_at' },
+                  { direction: 'desc', column: 'id' }
+                ]
               })
             } else {
               {
@@ -292,10 +292,10 @@ const User = new GraphQLObjectType({
                   sortKey: args =>
                     args.sortOnMain
                       ? null
-                      : {
-                          order: 'ASC',
-                          key: ['created_at', 'followee_id']
-                        }
+                      : [
+                          { direction: 'ASC', column: 'created_at' },
+                          { direction: 'ASC', column: 'followee_id' }
+                        ]
                 })
               }
             },

--- a/test-api/schema-paginated/User.js
+++ b/test-api/schema-paginated/User.js
@@ -167,11 +167,11 @@ const User = new GraphQLObjectType({
           ...do {
             if (PAGINATE === 'offset') {
               ;({
-                orderBy: args => ({
+                orderBy: args => [
                   // eslint-disable-line no-unused-vars
-                  created_at: 'desc',
-                  id: 'asc'
-                })
+                  { column: 'created_at', direction: 'desc' },
+                  { column: 'id', direction: 'asc' }
+                ]
               })
             } else if (PAGINATE === 'keyset') {
               ;({
@@ -235,10 +235,10 @@ const User = new GraphQLObjectType({
               ;({
                 orderBy: args =>
                   args.sortOnMain
-                    ? {
-                        created_at: 'ASC',
-                        id: 'ASC'
-                      }
+                    ? [
+                        { column: 'created_at', direction: 'ASC' },
+                        { column: 'id', direction: 'ASC' }
+                      ]
                     : null
               })
             } else if (PAGINATE === 'keyset') {
@@ -391,10 +391,10 @@ const User = new GraphQLObjectType({
           ...do {
             if (PAGINATE === 'offset') {
               ;({
-                orderBy: {
-                  id: 'ASC',
-                  created_at: 'ASC'
-                }
+                orderBy: [
+                  { column: 'id', direction: 'ASC' },
+                  { column: 'created_at', direction: 'ASC' }
+                ]
               })
             } else if (PAGINATE === 'keyset') {
               ;({

--- a/test-d/index.test-d.ts
+++ b/test-d/index.test-d.ts
@@ -36,7 +36,7 @@ new GraphQLObjectType<any, ExampleContext>({
             { column: 'bar', direction: 'DESC' }
           ],
           sortKey: {
-            order: 'ASC',
+            order: 'ASC', // old style of sortKey
             key: ['id']
           },
           sqlBatch: {
@@ -87,18 +87,20 @@ new GraphQLObjectType<any, ExampleContext>({
           orderBy: (args, context) => {
             expectType<ExampleArgs>(args)
             expectType<ExampleContext>(context)
-            return {
-              foo: 'ASC',
-              bar: 'DESC'
-            }
+            return [
+              { column: 'foo', direction: 'ASC' },
+              { column: 'bar', direction: 'DESC' }
+            ]
           },
           sortKey: (args, context) => {
             expectType<ExampleArgs>(args)
             expectType<ExampleContext>(context)
-            return {
-              order: 'ASC',
-              key: ['id']
-            }
+            return [
+              {
+                direction: 'ASC',
+                column: 'id'
+              }
+            ]
           }
         }
       }

--- a/test-d/index.test-d.ts
+++ b/test-d/index.test-d.ts
@@ -31,10 +31,10 @@ new GraphQLObjectType<any, ExampleContext>({
           ignoreAll: true,
           ignoreTable: true,
           limit: 10,
-          orderBy: {
-            foo: 'ASC',
-            bar: 'DESC'
-          },
+          orderBy: [
+            { column: 'foo', direction: 'asc' },
+            { column: 'bar', direction: 'DESC' }
+          ],
           sortKey: {
             order: 'ASC',
             key: ['id']


### PR DESCRIPTION
The API for `sortKey` right now lets you sort by multiple keys but only in one direction for all of them, which is a bit limiting, especially if you want to let API consumers pass arbitrary sorts or lists of sorts to paginated connections. `orderBy` lets you sort by as many keys as you like with independent directions per key -- I think `sortKey` should support the same!

This changes the API for `sortKey` from this:

```javascript
{
  order: "asc",
  key: ["created_at", "id"]
}
```

to this:

```javascript
[
  {order: "asc", key: "created_at"},
  {order: "asc", key: "id"},
]
```

which is more expressive, allowing different orders per key, and keeps the key property of ordering the keys so we know which to sort by first. `orderBy`'s object syntax kind of has that implicitly from object iteration order, but this makes it explicit which I think is better and less surprising.

The API is backwards compatible, if an object is passed to `sortKey` the old logic that applies the one order to all the keys will still run, and the new format only kicks in if an array is passed. 🎈  

I considered using `orderBy`'s same style of `{[key: string]: Order}` but I think this is more explicit. Relying on object insertion order to power super key API semantics like how things are sorted seems a little haphazard to me, and it means that the SQL output becomes super dependent on how an ordering thunk is implemented, not just it's output. To be honest I'd consider switching `orderBy` to be consistent and use the same explicitly ordered array of key/order pairs. An array of strings would also be good to support things like #321 and #313. If #418 means a big breaking change, it might be a good time to swap in that behaviour. Again, if an array were used, I think it'd be possible to make the API change backwards compatible way so people migrating to 3.0 didn't have to change their code just to make my API design OCD satisfied, but for new people integrating join-monster things would be that much better.