### PR TITLE
[WIP] Add filter system functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7224,6 +7224,12 @@
       "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
       "dev": true
     },
+    "graphql": {
+      "version": "15.4.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.4.0.tgz",
+      "integrity": "sha512-EB3zgGchcabbsU9cFe1j+yxdzKQKAbGUWRb13DsrsMN1yyfmmIq+2+L5MqVWcDCE4V89R5AyUOi7sMOGxdsYtA==",
+      "dev": true
+    },
     "graphql-relay": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/graphql-relay/-/graphql-relay-0.6.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7224,12 +7224,6 @@
       "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
       "dev": true
     },
-    "graphql": {
-      "version": "15.2.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.2.0.tgz",
-      "integrity": "sha512-tsceRyHfgzZo+ee0YK3o8f0CR0cXAXxRlxoORWFo/CoM1bVy3UXGWeyzBcf+Y6oqPvO27BDmOEVATcunOO/MrQ==",
-      "dev": true
-    },
     "graphql-relay": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/graphql-relay/-/graphql-relay-0.6.0.tgz",

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "eslint-config-airbnb-base": "^14.1.0",
     "eslint-config-prettier": "^6.11.0",
     "faker": "^4.1.0",
+    "graphql": "^15.4.0",
     "graphsiql": "0.2.0",
     "idx": "^2.5.6",
     "jsdoc-to-markdown": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,6 @@
     "eslint-config-airbnb-base": "^14.1.0",
     "eslint-config-prettier": "^6.11.0",
     "faker": "^4.1.0",
-    "graphql": "^15.2.0",
     "graphsiql": "0.2.0",
     "idx": "^2.5.6",
     "jsdoc-to-markdown": "^5.0.0",

--- a/src/query-ast-to-sql-ast/index.js
+++ b/src/query-ast-to-sql-ast/index.js
@@ -564,18 +564,20 @@ function _createJoinmap(
         )
 
         if (idx(type, _ => _.extensions.joinMonster.sqlTable)) {
+          const sqlTable = unthunk(ensure(type.extensions.joinMonster, 'sqlTable'), node.args || {}, context)
+          
           if (!existingNode) {
             const newNode = new SQLASTNode(currentJAstNode, {
               type: 'table',
-              name: type.extensions.joinMonster.sqlTable,
+              name: sqlTable,
               as: namespace.generate(
                 'table',
-                type.extensions.joinMonster.sqlTable
+                sqlTable
               ),
               fieldName: part,
               children: []
             })
-
+            
             if (field.extensions.joinMonster.sqlJoin) {
               newNode.sqlJoin = field.extensions.joinMonster.sqlJoin
             } else if (field.extensions.joinMonster.junction) {
@@ -602,7 +604,6 @@ function _createJoinmap(
           }
         } else {
           if (!existingNode) {
-            //const name = field.extensions.joinMonster.sqlColumn || part
             const name =
               idx(field, _ => _.extensions.joinMonster.sqlColumn) || part
             const newNode = new SQLASTNode(currentJAstNode, {

--- a/src/query-ast-to-sql-ast/index.js
+++ b/src/query-ast-to-sql-ast/index.js
@@ -559,6 +559,8 @@ function _createJoinmap(
           joinAst.fieldName
         )
 
+        gqlType = type
+
         const existingNode = currentJAstNode.children.find(
           child => child.fieldName === part
         )
@@ -634,7 +636,7 @@ function getFieldAndTypeForFilterKeyPart(
 
   if (!correspondingField)
     throw new Error(
-      `Wrong filter key part '${part}', the type '${gqlType.name}' does not contain this field.` +
+      `Wrong filter key part '${filterKeyPart}', the type '${gqlType.name}' does not contain this field.` +
         ` Check your filter at the '${rootFieldName}' field`
     )
 

--- a/src/query-ast-to-sql-ast/index.js
+++ b/src/query-ast-to-sql-ast/index.js
@@ -615,45 +615,6 @@ function _createJoinmap(
             currentJAstNode.children.push(newNode)
           }
         }
-
-        /*
-            if (field.sqlJoin) {
-              newNode.sqlJoin = field.sqlJoin
-            } else if (field.junction) {
-              const junctionTable = unthunk(
-                ensure(field.junction, 'sqlTable'),
-                node.args || {},
-                context
-              )
-              const junction = newNode.junction = {
-                sqlTable: junctionTable,
-                as: namespace.generate('table', junctionTable)
-              }
-
-              if (field.junction.sqlJoins) {
-                junction.sqlJoins = field.junction.sqlJoins
-              }
-            }
-
-            currentJAstNode.children.push(newNode)
-            currentJAstNode = newNode
-          } else {
-            currentJAstNode = existingNode
-          }
-        } else {
-          if (!existingNode) {
-            const name = field.sqlColumn || part
-            const newNode = new SQLASTNode(currentJAstNode, {
-              type: 'column',
-              name: name,
-              as: namespace.generate('column', name),
-              fieldName: part
-            })
-
-            currentJAstNode.children.push(newNode)
-          }
-        }
-        */
       })
     } else {
       throw new Error(

--- a/src/stringifiers/dispatcher.js
+++ b/src/stringifiers/dispatcher.js
@@ -762,6 +762,13 @@ async function handleTable(
     await dialect.handlePaginationAtRoot(parent, node, context, tables)
   } else {
     if (node.filteredWhere) {
+      assert(
+        !parent,
+        `Object type for "${node.fieldName}" table must have a "sqlJoin" or "sqlBatch"`
+      )
+  
+      tables.push(`FROM ${node.name} ${q(node.as)}`)
+      
       handleFilteredWhere(
         selections,
         tables,
@@ -772,13 +779,6 @@ async function handleTable(
         context
       )
     }
-
-    assert(
-      !parent,
-      `Object type for "${node.fieldName}" table must have a "sqlJoin" or "sqlBatch"`
-    )
-
-    tables.push(`FROM ${node.name} ${q(node.as)}`)
   }
 }
 

--- a/src/stringifiers/dispatcher.js
+++ b/src/stringifiers/dispatcher.js
@@ -399,15 +399,16 @@ async function handleFilteredJoin(
 
   const filterConditions = assembleFilterConditions(node, joinAst, q, 'join')
 
-  const str = `LEFT JOIN (
-           SELECT
-               ${q(node.as)}.*${selections.length > 0 ? ',' : ''}
-               ${selections.join(',\n')}
-           FROM ${node.name} ${q(node.as)}
-               ${joins.join('\n')}
-       ) AS ${q(node.as)}
-           ON ${standardJoinCondition}
-               AND ( ${filterConditions} )`
+  const str = 
+  `  LEFT JOIN (
+      SELECT
+        ${q(node.as)}.*${selections.length > 0 ? ',' : ''}
+        ${selections.length > 0 ? selections.join(',\n') : ''}
+      FROM ${node.name} ${q(node.as)}
+        ${joins.join('\n')}
+      ) AS ${q(node.as)}
+        ON ${standardJoinCondition}
+        AND ( ${filterConditions} )`
 
   return str
 }
@@ -458,7 +459,7 @@ function _joinAstToLists(
 
         joins.push({
           as: child,
-          sql: `LEFT JOIN ${child.name} ${q(child.as)} ON ${joinCondition}`
+          sql: `  LEFT JOIN ${child.name} ${q(child.as)} ON ${joinCondition}`
         })
       } else if (idx(child,_ => _.junction.sqlTable) && idx(child, _ => _.junction.sqlJoins)) {
         const joinCondition1 = child.junction.sqlJoins[0](
@@ -480,13 +481,13 @@ function _joinAstToLists(
         joins.push(
           {
             as: child.junction.as,
-            sql: `LEFT JOIN ${child.junction.sqlTable} ${q(
+            sql: `  LEFT JOIN ${child.junction.sqlTable} ${q(
               child.junction.as
             )} ON ${joinCondition1}`
           },
           {
             as: child.as,
-            sql: `LEFT JOIN ${child.name} ${q(child.as)} ON ${joinCondition2}`
+            sql: `  LEFT JOIN ${child.name} ${q(child.as)} ON ${joinCondition2}`
           }
         )
       }
@@ -610,7 +611,7 @@ async function handleTable(
 
       tables.push(filteredJoin)
     } else {
-      tables.push(`LEFT JOIN ${node.name} ${q(node.as)} ON ${joinCondition}`)
+      tables.push(`  LEFT JOIN ${node.name} ${q(node.as)} ON ${joinCondition}`)
     }
 
     // many-to-many using batching

--- a/src/stringifiers/dispatcher.js
+++ b/src/stringifiers/dispatcher.js
@@ -460,12 +460,7 @@ function _joinAstToLists(
           as: child,
           sql: `LEFT JOIN ${q(child.name)} ${q(child.as)} ON ${joinCondition}`
         })
-      } else if (
-        idx(
-          child,
-          _ => _.junction.sqlTable && idx(child, _ => _.junction.sqlJoins)
-        )
-      ) {
+      } else if (idx(child,_ => _.junction.sqlTable) && idx(child, _ => _.junction.sqlJoins)) {
         const joinCondition1 = child.junction.sqlJoins[0](
           q(currentNode.as),
           q(child.junction.as),

--- a/src/stringifiers/dispatcher.js
+++ b/src/stringifiers/dispatcher.js
@@ -458,7 +458,7 @@ function _joinAstToLists(
 
         joins.push({
           as: child,
-          sql: `LEFT JOIN ${q(child.name)} ${q(child.as)} ON ${joinCondition}`
+          sql: `LEFT JOIN ${child.name} ${q(child.as)} ON ${joinCondition}`
         })
       } else if (idx(child,_ => _.junction.sqlTable) && idx(child, _ => _.junction.sqlJoins)) {
         const joinCondition1 = child.junction.sqlJoins[0](
@@ -777,6 +777,7 @@ async function handleTable(
       !parent,
       `Object type for "${node.fieldName}" table must have a "sqlJoin" or "sqlBatch"`
     )
+
     tables.push(`FROM ${node.name} ${q(node.as)}`)
   }
 }

--- a/test-api/schema-basic/QueryRoot.js
+++ b/test-api/schema-basic/QueryRoot.js
@@ -3,7 +3,8 @@ import {
   GraphQLList,
   GraphQLString,
   GraphQLInt,
-  GraphQLBoolean
+  GraphQLBoolean,
+  GraphQLInputObjectType
 } from 'graphql'
 
 import knex from './database'
@@ -19,6 +20,7 @@ import pgModule from '../../src/stringifiers/dialects/pg'
 import sqlite3Module from '../../src/stringifiers/dialects/sqlite3'
 
 import joinMonster from '../../src/index'
+import FilterInput from './filterInput'
 
 const { MINIFY, DB } = process.env
 const options = {
@@ -52,7 +54,8 @@ export default new GraphQLObjectType({
     users: {
       type: new GraphQLList(User),
       args: {
-        ids: { type: new GraphQLList(GraphQLInt) }
+        ids: { type: new GraphQLList(GraphQLInt) },
+        filter: { type: FilterInput }
       },
       extensions: {
         joinMonster: {

--- a/test-api/schema-basic/User.js
+++ b/test-api/schema-basic/User.js
@@ -16,6 +16,7 @@ import Person from './Person'
 import AuthoredInterface from './Authored/Interface'
 import AuthoredUnion from './Authored/Union'
 import { toBase64, q, bool } from '../shared'
+import FilterInput from './filterInput'
 
 const { STRATEGY, DB } = process.env
 
@@ -127,6 +128,9 @@ const User = new GraphQLObjectType({
         active: {
           description: 'Get only posts not archived',
           type: GraphQLBoolean
+        },
+        filter: {
+          type: FilterInput
         }
       },
       extensions: {

--- a/test-api/schema-basic/filterInput.js
+++ b/test-api/schema-basic/filterInput.js
@@ -1,0 +1,37 @@
+import { GraphQLList, GraphQLNonNull, GraphQLString } from 'graphql'
+import {
+    GraphQLInputObjectType
+} from 'graphql'
+
+const FilterInput = new GraphQLInputObjectType({
+    name: 'FilterInput',
+    description: 'Filter input',
+    fields: () => ({
+        compare: {
+            type: ComparisonInput,
+        },
+        AND: {
+            type: GraphQLList(FilterInput)
+        },
+        OR: {
+            type: GraphQLList(FilterInput)
+        }
+    })
+})
+
+const ComparisonInput = new GraphQLInputObjectType({
+    name: 'ComparisonInput',
+    fields: () => ({
+        key: {
+            type: GraphQLNonNull(GraphQLString)
+        },
+        operator: {
+            type: GraphQLNonNull(GraphQLString)
+        },
+        value: {
+            type: GraphQLNonNull(GraphQLString)
+        }
+    })
+})
+
+export default FilterInput;


### PR DESCRIPTION
I would like to propose this filter system which can be plugged into graphql fields via an argument.

By now, it supports nested (OR + AND) filtering for (AFAIK) arbitrary depths for non-paginated queries.

You can test it with the test-api with the rootquery/users field and the rootquery/users/posts field.