### PR TITLE
…

### DIFF
--- a/src/query-ast-to-sql-ast/index.js
+++ b/src/query-ast-to-sql-ast/index.js
@@ -235,8 +235,13 @@ export function populateASTNode(
       aliasFrom += '@' + parentTypeNode.name
     }
     sqlASTNode.as = namespace.generate('column', aliasFrom)
-    // is it just a column? if they specified a sqlColumn or they didn't define a resolver, yeah
-  } else if (fieldConfig.sqlColumn || !field.resolve) {
+    // or maybe it just depends on some SQL columns
+  } else if (fieldConfig.sqlDeps) {
+    sqlASTNode.type = 'columnDeps'
+    sqlASTNode.names = fieldConfig.sqlDeps
+    // is it just a column? if they specified a sqlColumn or parentTypeNode is a GraphQLObjectType, yeah
+    // recent apollo-server-core always define a field resolver (see enablePluginsForSchemaResolvers function, #3988)
+  } else if (fieldConfig.sqlColumn || parentTypeNode.constructor.name === 'GraphQLObjectType') {
     sqlASTNode.type = 'column'
     sqlASTNode.name = fieldConfig.sqlColumn || field.name
     let aliasFrom = (sqlASTNode.fieldName = field.name)
@@ -244,10 +249,6 @@ export function populateASTNode(
       aliasFrom += '@' + parentTypeNode.name
     }
     sqlASTNode.as = namespace.generate('column', aliasFrom)
-    // or maybe it just depends on some SQL columns
-  } else if (fieldConfig.sqlDeps) {
-    sqlASTNode.type = 'columnDeps'
-    sqlASTNode.names = fieldConfig.sqlDeps
     // maybe this node wants no business with your SQL, because it has its own resolver
   } else {
     sqlASTNode.type = 'noop'


### PR DESCRIPTION
Using recent apollo-server-core populateASTNode(..) don't detect most columns if sqlColumn is not set.
Digging I found that recent apollo-server-core always define a field resolver (see 
[#3988 enablePluginsForSchemaResolvers() function](https://github.com/apollographql/apollo-server/pull/3988/files#diff-7c8042bc5269149ffa902b11bcb17987b60d9f92a5d25c6f73dce23853269ca6)
) so "!field.resolve" is not a good check for columns.
I found using parentTypeNode.constructor.name === 'GraphQLObjectType' is correct in all cases I can test.