### PR TITLE
Setup Initial Github Actions

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -53,7 +53,10 @@ jobs:
       run: npm ci
 
     - name: Startup Databases
-      run: npm run db-up
+      run: |
+        npm run db-up
+        echo 'Waiting for DBs to start'
+        npm run db-wait
 
     - name: Build Test Databases
       run: npm run db-build

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -1,0 +1,60 @@
+#### LOCAL DEV COMMAND
+# To run this locally use the act command
+# Install from: https://github.com/nektos/act
+#
+# You will also need to temporarily update the volume mount paths in the
+# docker compose file to be absolute paths on your machine. This should be temporary,
+# but is necessary because of a bug with ACT: https://github.com/nektos/act/issues/410
+#
+# Run: act --platform ubuntu-latest=ubuntu-latest=nektos/act-environments-ubuntu:18.04
+# This will use a runner that has all the commands we need.
+#
+# Use the following for the node matrix locally, or any other value,
+# but you don't need all of them:
+# node-version: [10.x]
+#
+####
+
+name: CI Tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+        node-version: [10.x, 12.x, 13.x, 14.x]
+
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v2
+
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+
+    - name: Setup System
+      run: |
+        sudo apt-get update
+        sudo apt-get install sqlite3
+
+    - name: Install Node Deps
+      run: npm ci
+
+    - name: Startup Databases
+      run: npm run db-up
+
+    - name: Build Test Databases
+      run: npm run db-build
+
+    - name: Run Tests
+      run: npm test

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-        node-version: [10.x, 12.x, 13.x, 14.x]
+        node-version: [10.x, 12.x, 13.x, 14.x, 15.x]
 
     steps:
     - name: Checkout Repo

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -7,7 +7,9 @@
 # but is necessary because of a bug with ACT: https://github.com/nektos/act/issues/410
 #
 # Run: act --platform ubuntu-latest=ubuntu-latest=nektos/act-environments-ubuntu:18.04
-# This will use a runner that has all the commands we need.
+# This will use a runner that has all the commands we need. This should only be used to
+# modifying these actions, as the image is very large. If you are trying to run the
+# tests locally, simply run them in docker.
 #
 # Use the following for the node matrix locally, or any other value,
 # but you don't need all of them:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -14,7 +14,11 @@ services:
    - MYSQL_ROOT_PASSWORD=${DB_PASSWORD:-password}
   env_file:
    - ../.env
-     
+  healthcheck:
+    test: ["CMD", "mysqladmin" ,"ping", "-h", "localhost"]
+    timeout: 20s
+    retries: 10
+
  postgres:
   image: postgres
   restart: always

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "db-build": "TZ=UTC babel-node test-api/data/build.js",
     "db-shell": "sqlite3 --column --header test-api/data/db/demo-data.sl3",
     "db-up": "docker-compose -f ./docker/docker-compose.yml up -d",
-    "db-down": "docker-compose -f ./docker/docker-compose.yml down --remove-orphans -v"
+    "db-down": "docker-compose -f ./docker/docker-compose.yml down --remove-orphans -v",
+    "db-wait": "while ! echo exit | docker inspect --format \"{{json .State.Health.Status }}\" docker_mysql_1 | grep 'healthy'; do sleep 1; done"
   },
   "ava": {
     "verbose": true,


### PR DESCRIPTION
This is an initial port of the travis CI config to GitHub Actions. I made use of the docker-compose config as much as possible so that running tests locally is the same as on Github. If this is sufficient, we can remove the travis.yml or simply leave both for a while to ensure this works as expected.

The goal with this is to make the test outcomes more clear to contributors. Right now they must go to travis to see what failed and it can be unclear, this will give a clean picture of what test failed, within the GitHub interface.