### PR TITLE
Add Github Action for Linting

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+test-api

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -27,6 +27,7 @@ on:
 
 jobs:
   run-tests:
+    name: Run Tests
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -26,7 +26,7 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
+  run-tests:
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,34 @@
+name: Lint
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  run-linters:
+    name: Run linters
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v2
+
+      - name: Read .nvmrc
+        run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
+        id: nvm
+
+      - name: Use Node.js ${{ steps.nvm.outputs.NVMRC }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: "${{ steps.nvm.outputs.NVMRC }}"
+
+      - run: npm ci
+
+      - name: Run linters
+        uses: wearerequired/lint-action@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          # Enable your linters here
+          eslint: true


### PR DESCRIPTION
### Description

Add Linting Action, to automatically run Eslint against PRs and on master after a merge. This will add line anotations to PRs within the repo, but currently cannot add them for fork PRs.

### References

- [Action Used](https://github.com/marketplace/actions/lint-action)

### Testing
This will show at the bottom of this PR

- [X] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [X] I have added documentation for new/changed functionality in this PR via comments and by updating the change log
 > No code changes
- [X] All active GitHub checks for tests, formatting, and security are passing
