### PR TITLE
Fix apollo-server null issue due to missing columns

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,9 @@
+### v3.0.2 (April 4, 2021)
+
+#### Fixed
+
+- Fix apollo-server null issue due to missing columns [#444](https://github.com/join-monster/join-monster/pull/444)
+
 ### v3.0.0
 
 **Breaking changes:**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "join-monster",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "A GraphQL to SQL query execution layer for batch data fetching.",
   "main": "dist/index.js",
   "engines": {

--- a/test-api/schema-basic/User.js
+++ b/test-api/schema-basic/User.js
@@ -247,6 +247,11 @@ const User = new GraphQLObjectType({
     },
     favNums: {
       type: new GraphQLList(GraphQLInt),
+      extensions: {
+        joinMonster: {
+          ignoreAll: true
+        }
+      },
       resolve: () => [1, 2, 3]
     },
     numLegs: {


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Code of Conduct](https://github.com/join-monster/join-monster/blob/master/CODE_OF_CONDUCT.md). Please see the [contributing guidelines](https://github.com/join-monster/join-monster/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Recent apollo-server-core changes always define a field resolver (see enablePluginsForSchemaResolvers function, apollo-server issue #3988) so '!field.resolve' is not a good check for columns. Because of this, the query is not built correctly and does not included the requested columns, leading to all fields being null when using `ApolloServer`. Instead use parentTypeNode.constructor.name.

Current condition
```
if (fieldConfig.sqlColumn || !field.resolve)
```

Proposed condition
```
if (fieldConfig.sqlColumn || ['GraphQLObjectType', 'GraphQLInterfaceType'].includes(parentTypeNode.constructor.name))
```

### References

[Reference to existing PR in draft state](https://github.com/join-monster/join-monster/pull/436)

[Apollo Server breaking change](https://github.com/apollographql/apollo-server/pull/3988)

### Testing

Modified an existing test for `User > favNums` resolver to add `ignoreAll` since it does not use join-monster functionality.

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR via comments and by updating the change log
- [x] All active GitHub checks for tests, formatting, and security are passing
