### PR TITLE
Correct generic type argument order for ObjectTypeExtension sqlTable thunk

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -37,7 +37,7 @@ export type ThunkWithArgsCtx<T, TContext, TArgs> =
 
 export interface ObjectTypeExtension<TSource, TContext> {
   alwaysFetch?: string
-  sqlTable?: ThunkWithArgsCtx<string, any, TContext>
+  sqlTable?: ThunkWithArgsCtx<string, TContext, any>
   uniqueKey?: string | string[]
 }
 

--- a/test-d/index.test-d.ts
+++ b/test-d/index.test-d.ts
@@ -20,6 +20,21 @@ const User = new GraphQLObjectType({
   fields: {}
 })
 
+// test sqlTable thunk
+new GraphQLObjectType<any, ExampleContext>({
+  name: 'User',
+  extensions: {
+    joinMonster: {
+      sqlTable: (args, context) => {
+        expectType<any>(args)
+        expectType<ExampleContext>(context)
+        return 'expr'
+      }
+    }
+  },
+  fields: {}
+})
+
 // test field extensions
 new GraphQLObjectType<any, ExampleContext>({
   name: 'User',


### PR DESCRIPTION
### Description

I think I screwed this up in #418. We unthunk passing the context as the second argument here like we do everywhere else: https://github.com/join-monster/join-monster/blob/73ef3473713bf88e955188ec888a8a0540cabef6/src/query-ast-to-sql-ast/index.js#L275 . Confusingly, the `ThunkWithArgsCtx` takes the type arguments in a different order than the function it represents, but I think it's not worth causing a breaking change to make these aligned.
### Testing

Can be tested by running `npm run testtsd`

- [X] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [X] I have added documentation for new/changed functionality in this PR via comments and by updating the change log
- [x] All active GitHub checks for tests, formatting, and security are passing
