### PR TITLE
Typescript - update alwaysFetch to accept array

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -36,7 +36,7 @@ export type ThunkWithArgsCtx<T, TContext, TArgs> =
   | T
 
 export interface ObjectTypeExtension<TSource, TContext> {
-  alwaysFetch?: string
+  alwaysFetch?: string | string[]
   sqlTable?: ThunkWithArgsCtx<string, TContext, any>
   uniqueKey?: string | string[]
 }
@@ -93,13 +93,13 @@ export interface FieldConfigExtension<TSource, TContext, TArgs> {
 export interface UnionTypeExtension {
   sqlTable?: string
   uniqueKey?: string | string[]
-  alwaysFetch?: string
+  alwaysFetch?: string | string[]
 }
 
 export interface InterfaceTypeExtension {
   sqlTable?: string
   uniqueKey?: string | string[]
-  alwaysFetch?: string
+  alwaysFetch?: string | string[]
 }
 
 declare module 'graphql' {


### PR DESCRIPTION
The alwaysFetch param is treated as an array or string in the actual code base (and in the docs) but typescript complains when passing in an array
