### PR TITLE
maybeQuote now handles BigInts properly

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "coverage": "nyc --reporter=html npm run test",
     "view-coverage": "open coverage/index.html",
     "lint": "eslint src test",
-    "prettier": "prettier --write src/**/*.js test/**/*.js test-api/**/*.js",
+    "prettier": "prettier --write \"src/**/*.js\" \"test/**/*.js\" \"test-api/**/*.js\"",
     "start": "babel-watch ./test-api/server.js",
     "docs": "mkdocs serve",
     "jsdoc": "babel src/index.js -o temp.js && (jsdoc2md temp.js | sed '/\\*\\*Kind\\*\\*:/d' > docs/API.md) && rm temp.js",

--- a/src/array-to-connection.js
+++ b/src/array-to-connection.js
@@ -50,7 +50,6 @@ function arrToConnection(data, sqlAST) {
   // time changes it everywhere. we'll set the `_paginated` property to true to prevent this
   if (sqlAST.paginate && !data._paginated) {
     if (sqlAST.sortKey || idx(sqlAST, _ => _.junction.sortKey)) {
-      
       if (idx(sqlAST, _ => _.args.first)) {
         // we fetched an extra one in order to determine if there is a next page, if there is one, pop off that extra
         if (data.length > sqlAST.args.first) {
@@ -70,8 +69,8 @@ function arrToConnection(data, sqlAST) {
           pageInfo.hasNextPage = true
           data.pop()
         }
-      }  
-  
+      }
+
       // convert nodes to edges and compute the cursor for each
       // TODO: only compute all the cursor if asked for them
       const sortKey = sqlAST.sortKey || sqlAST.junction.sortKey
@@ -96,7 +95,10 @@ function arrToConnection(data, sqlAST) {
       // $total was a special column for determining the total number of items
       const arrayLength = data[0] && parseInt(data[0].$total, 10)
       let defaultArgs = sqlAST.args
-      if (idx(sqlAST, _ => _.defaultPageSize) && !idx(defaultArgs, _=>_.first)) {
+      if (
+        idx(sqlAST, _ => _.defaultPageSize) &&
+        !idx(defaultArgs, _ => _.first)
+      ) {
         defaultArgs.first = sqlAST.defaultPageSize
       }
       const connection = connectionFromArraySlice(data, defaultArgs, {
@@ -107,7 +109,6 @@ function arrToConnection(data, sqlAST) {
       connection._paginated = true
       return connection
     }
-    
   }
   return data
 }

--- a/src/util.js
+++ b/src/util.js
@@ -72,7 +72,7 @@ export function maybeQuote(value, dialectName) {
     return 'NULL'
   }
 
-  if (typeof value === 'number') return value
+  if (typeof value === 'number' || typeof value === 'bigint') return value
   if (value && typeof value.toSQL === 'function') return value.toSQL()
   if (
     value instanceof Buffer &&

--- a/test/maybeQuote.js
+++ b/test/maybeQuote.js
@@ -1,0 +1,59 @@
+import test from 'ava'
+import { maybeQuote } from '../src/util'
+
+test('it should handle a bigint input', async t => {
+  const output = maybeQuote(24n, 'postgres')
+  const expected = 24n
+  t.deepEqual(output, expected)
+})
+
+test('it should handle a number input', async t => {
+  const output = maybeQuote(24, 'postgres')
+  const expected = 24
+  t.deepEqual(output, expected)
+})
+
+test('it should handle an empty value', async t => {
+  const output = maybeQuote(null, 'postgres')
+  const expected = 'NULL'
+  t.deepEqual(output, expected)
+})
+
+test('it should handle a date value in non-oracle dialects', async t => {
+  const output = maybeQuote('1970-01-01T01:01:01', 'postgres')
+  const expected = "'1970-01-01T01:01:01'"
+  t.deepEqual(output, expected)
+})
+
+test('it should handle a date value in oracle dialects', async t => {
+  const output = maybeQuote('1970-01-01T01:01:01', 'oracle')
+  const expected = "TIMESTAMP '1970-01-01 01:01:01 UTC'"
+  t.deepEqual(output, expected)
+})
+
+test('it should handle a buffer input', async t => {
+  const output = maybeQuote(
+    Buffer.from([0x62, 0x75, 0x66, 0x66, 0x65, 0x72]),
+    'postgres'
+  )
+  const expected = "X'627566666572'"
+  t.deepEqual(output, expected)
+})
+
+test('it should handle a string with no special characters', async t => {
+  const output = maybeQuote('string', 'postgres')
+  const expected = "'string'"
+  t.deepEqual(output, expected)
+})
+
+test('it should escape quotes', async t => {
+  const output = maybeQuote("'string'")
+  const expected = "'''string'''"
+  t.deepEqual(output, expected)
+})
+
+test('it should escape backslashes', async t => {
+  const output = maybeQuote("string/'string'")
+  const expected = "'string/''string'''"
+  t.deepEqual(output, expected)
+})


### PR DESCRIPTION
Currently utils.maybeQuote will incorrectly return `'' ` for any bigint value provided to it. This updates it to correctly return early as all other numbers do. 

I noticed while writing tests that the path for prettier wasn't matching all files properly. It was matching files within a nested folder, but not ones at the top level of src, test, and test-api. From the [prettier docs](https://prettier.io/docs/en/cli.html) adding quotes is necessary for globs:

> Don’t forget the quotes around the globs! The quotes make sure that Prettier CLI expands the globs rather than your shell, which is important for cross-platform usage.

So I fixed that and it found some lint issues in an existing file