### PR TITLE
Expose joinMonsterBatch to allow re-entry and delegate type

### DIFF
--- a/src/batch-planner/index.js
+++ b/src/batch-planner/index.js
@@ -33,7 +33,7 @@ async function nextBatch(sqlAST, data, dbCall, context, options) {
 }
 
 // processes a single child of the batch
-async function nextBatchChild(childAST, data, dbCall, context, options) {
+export async function nextBatchChild(childAST, data, dbCall, context, options) {
   if (childAST.type !== 'table' && childAST.type !== 'union') return
 
   const fieldName = childAST.fieldName

--- a/src/define-object-shape.js
+++ b/src/define-object-shape.js
@@ -30,6 +30,7 @@ function _defineObjectShape(parent, prefix, node) {
       case 'expression':
         fieldDefinition[child.fieldName] = prefixToPass + child.as
         break
+      case 'delegated':
       case 'union':
       case 'table':
         if (child.sqlBatch) {
@@ -81,6 +82,7 @@ function _defineObjectShape(parent, prefix, node) {
             fieldDefinition[child.fieldName + suffix] = definition
           }
           break
+        case 'delegated':
         case 'noop':
           void 0
           break

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -39,6 +39,7 @@ export interface ObjectTypeExtension<TSource, TContext> {
   alwaysFetch?: string | string[]
   sqlTable?: ThunkWithArgsCtx<string, TContext, any>
   uniqueKey?: string | string[]
+  delegated?: boolean
 }
 
 export interface FieldConfigExtension<TSource, TContext, TArgs> {
@@ -88,6 +89,7 @@ export interface FieldConfigExtension<TSource, TContext, TArgs> {
   sqlPageLimit?: number
   sqlDefaultPageSize?: number
   where?: Where<TContext, TArgs>
+  delegated?: boolean
 }
 
 export interface UnionTypeExtension {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -157,4 +157,12 @@ declare function joinMonster(
   options?: JoinMonsterOptions
 ): Promise<any>
 
+export function joinMonsterBatch(
+  data: any,
+  resolveInfo: any,
+  context: any,
+  dbCall: DbCallCallback | DbCallPromise,
+  options?: JoinMonsterOptions
+): Promise<any>
+
 export default joinMonster

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ import assert from 'assert'
 import * as queryAST from './query-ast-to-sql-ast'
 import arrToConnection from './array-to-connection'
 import AliasNamespace from './alias-namespace'
-import nextBatch from './batch-planner'
+import nextBatch, { nextBatchChild } from './batch-planner'
 import {
   buildWhereFunction,
   handleUserDbCall,
@@ -114,6 +114,14 @@ async function joinMonster(resolveInfo, context, dbCall, options = {}) {
       return true
     })
   }
+
+  return data
+}
+
+export async function joinMonsterBatch(data, resolveInfo, context, dbCall, options = {}) {
+  const sqlAST = queryAST.queryASTToSqlAST(resolveInfo, options, context)
+
+  await nextBatchChild(sqlAST, data, dbCall, context, options)
 
   return data
 }

--- a/src/query-ast-to-sql-ast/index.js
+++ b/src/query-ast-to-sql-ast/index.js
@@ -98,7 +98,7 @@ export function queryASTToSqlAST(resolveInfo, options, context) {
 
   // make sure they started this party on a table, interface or union.
   assert.ok(
-    ['table', 'union'].indexOf(sqlAST.type) > -1,
+    ['table', 'union', 'delegated'].indexOf(sqlAST.type) > -1,
     'Must call joinMonster in a resolver on a field where the type is decorated with "sqlTable".'
   )
 
@@ -262,7 +262,12 @@ export function populateASTNode(
       parentTypeNode.constructor.name
     )
   ) {
-    sqlASTNode.type = 'column'
+    if (fieldConfig.delegated) {
+      sqlASTNode.type = 'delegated'
+    } else {
+      sqlASTNode.type = 'column'
+    }
+
     sqlASTNode.name = fieldConfig.sqlColumn || field.name
     let aliasFrom = (sqlASTNode.fieldName = field.name)
     if (sqlASTNode.defferedFrom) {
@@ -288,7 +293,12 @@ function handleTable(
   const config = getConfigFromSchemaObject(gqlType)
   const fieldConfig = getConfigFromSchemaObject(field)
 
-  sqlASTNode.type = 'table'
+  if (fieldConfig.delegated || config.delegated) {
+    sqlASTNode.type = 'delegated'
+  } else {
+    sqlASTNode.type = 'table'
+  }
+
   const sqlTable = unthunk(config.sqlTable, sqlASTNode.args || {}, context)
   sqlASTNode.name = sqlTable
 

--- a/src/stringifiers/dispatcher.js
+++ b/src/stringifiers/dispatcher.js
@@ -71,6 +71,7 @@ async function _stringifySqlAST(
   const { quote: q } = dialect
   const parentTable = node.fromOtherTable || (parent && parent.as)
   switch (node.type) {
+    case 'delegated':
     case 'table':
       await handleTable(
         parent,


### PR DESCRIPTION
### Description

The problem we are facing is that we want to have certain models in our graphql schema powered by an alternative data store (non-sql). The remainder of the schema relies heavily on join monster for generating appropriate queries, filtering, sorting etc and building the relationships between the models. We want to maintain the same behaviours from before that a sql backed model and the new datastore can be related (has many, belongs to). 

This means that we need to tell join monster to not perform the queries to load from this new model. In many ways this is similar to the existing no-op case where join monster is instructed to ignore the field and perform regular resolve methods. There are some slight differences, in our case we still want to let join monster know that the relationship exists. For example we want it to fetch the foreign keys to join with our other model. Just using noop loses this information and the field is entirely ignored.

The other problem is we want to re-enter join monster after our other model has finished resolving to continue fetching data for the child fields. However we still want to avoid n+1 issues. For example given the following query, where `sessions` is powered by our new datastore and `user` is backed by join monster.

```
sessions {
  id
  user {
    id
    name
  }
}
```

We want to fetch all `user` fields in a single query. By exposing the `nextBatchChild` we can build a dataloader that receives all the session data and join monster will generate the appropriate queries for the children (exactly how it would if you defined a separate batch regularly).

I could not use the regular `joinMonster` API as the assumption is that you are resolving a single object (typically query object). This means that even if you pass through the `batchScope` options; which makes join-monster fetch multiple records; the shape data is incorrect and therefore not hydrated properly. 

By submitting a PR to this repository, you agree to the terms within the [Code of Conduct](https://github.com/join-monster/join-monster/blob/master/CODE_OF_CONDUCT.md). Please see the [contributing guidelines](https://github.com/join-monster/join-monster/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Testing

> Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.
>
> Also include details of the environment this PR was developed in (language/platform/browser version).

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR via comments and by updating the change log
