### PR TITLE
Patch to ensure field.args is array for graphql-js (v16+)

### DIFF
--- a/src/query-ast-to-sql-ast/index.js
+++ b/src/query-ast-to-sql-ast/index.js
@@ -163,7 +163,9 @@ export function populateASTNode(
   let grabMany = false
   // the actual type might be wrapped in a GraphQLNonNull type
   let gqlType = stripNonNullType(field.type)
-
+  // patch for building node query - expectation in qraphql-js 16+ is that field.args is iterable (array)
+  // so convert field.args into Array if it's not an array aleady.
+  if (field && field.args && !Array.isArray(field.args)) field.args = [field.args]; 
   sqlASTNode.args = getArgumentValues(field, queryASTNode, this.variableValues)
 
   // if list then mark flag true & get the type inside the GraphQLList container type

--- a/src/query-ast-to-sql-ast/index.js
+++ b/src/query-ast-to-sql-ast/index.js
@@ -165,7 +165,7 @@ export function populateASTNode(
   let gqlType = stripNonNullType(field.type)
   // patch for building node query - expectation in qraphql-js 16+ is that field.args is iterable (array)
   // so convert field.args into Array if it's not an array aleady.
-  if (field && field.args && !Array.isArray(field.args)) field.args = [field.args]; 
+  if (field && field.args && !Array.isArray(field.args)) field.args = [field.args] 
   sqlASTNode.args = getArgumentValues(field, queryASTNode, this.variableValues)
 
   // if list then mark flag true & get the type inside the GraphQLList container type


### PR DESCRIPTION
### Description

This is related to Issue 476 (Issue https://github.com/join-monster/join-monster/issues/476)

When node query is constructed using joinMonster.getNode, graphql cannot evaluate field.args as it expects an iterable instead of a single object. This patch checks if field.args exist and if it's iterable and if it's not it creates an iterable.

### References

[Issue 476](https://github.com/join-monster/join-monster/issues/476)
[Sample of failing code](https://github.com/moltco/monstertest)

