### PR TITLE
Ensure that empty fallback has page info

### DIFF
--- a/src/batch-planner/index.js
+++ b/src/batch-planner/index.js
@@ -81,7 +81,18 @@ async function nextBatchChild(childAST, data, dbCall, context, options) {
         for (let obj of data) {
           obj[fieldName] =
             newData[obj[parentKey]] ||
-            (childAST.paginate ? { total: 0, edges: [] } : [])
+            (childAST.paginate
+              ? {
+                  total: 0,
+                  edges: [],
+                  pageInfo: {
+                    startCursor: null,
+                    endCursor: null,
+                    hasNextPage: false,
+                    hasPreviousPage: false
+                  }
+                }
+              : [])
         }
       } else {
         let matchedData = []

--- a/test/pagination/offset-paging.js
+++ b/test/pagination/offset-paging.js
@@ -523,6 +523,32 @@ test('should handle emptiness', async t => {
   t.deepEqual(expect, data)
 })
 
+test('should handle emptiness for nested connections', async t => {
+  const query = `{
+    users {
+      edges {
+        node {
+          comments {
+            pageInfo {
+              startCursor
+              endCursor
+              hasNextPage
+              hasPreviousPage
+            }
+            edges {
+              node {
+                id
+              }
+            }
+          }
+        }
+      }
+    }
+  }`
+  const { errors } = await run(query)
+  errCheck(t, errors)
+})
+
 test('should handle a post without an author', async t => {
   const query = `{
     node(id: "${toGlobalId('Post', 19)}") {


### PR DESCRIPTION
@airhorns 

By submitting a PR to this repository, you agree to the terms within the [Code of Conduct](https://github.com/join-monster/join-monster/blob/master/CODE_OF_CONDUCT.md). Please see the [contributing guidelines](https://github.com/join-monster/join-monster/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

This addresses a specific case when we are fetching a paginated collection as the child of another field that returns multiple options in batch mode. In the example from the test; in the case where a user has no comments when loading in batch mode the key is not present in the returned data. This leads `newData[obj[parentKey]]` to be `undefined` and falls back to an empty collection.

The empty set did not previously contain `pageInfo` key with the required information for relay connection spec which causes the following graphql error:

```
Cannot return null for non-nullable field CommentConnection.pageInfo.
```

This PR adds a default blank `pageInfo` object when falling back.


### Testing

A regression test was added that fails when running the following command:

```
STRATEGY=batch npm run testpg-paging
```

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR via comments and by updating the change log
