### PR TITLE
Support different arguments for different aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,6 @@ Explore the schema, try out some queries, and see what the resulting SQL queries
 
 ## Future Work
 
-- [ ] Address this known bug [#126](https://github.com/join-monster/join-monster/issues/126).
 - [ ] Support custom `ORDER BY` expressions [#138](https://github.com/join-monster/join-monster/issues/138).
 - [ ] Support binding parameters [#169](https://github.com/join-monster/join-monster/issues/169).
 - [ ] Write static [Flow](https://flow.org/) types.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,28 @@
 ### vNEXT 
 
+**Breaking changes:**
+
+- Support querying the same fields and relations with different arguments through different aliases (fixes [#126](https://github.com/join-monster/join-monster/issues/126))
+  - It is no longer guaranteed that a field's value is available under `source[fieldName]` in a custom resolver. Instead, custom resolvers on non-trivial fields should use GraphQL's default resolver to get the raw value:
+
+```javascript
+import { defaultFieldResolver } from 'graphql'
+
+const User = new GraphQLObjectType({
+  //...
+  fields: () => ({
+    //...
+    following: {
+      // ...
+      resolve: (source, args, context, info) => {
+        const rawValue = defaultFieldResolver(source, args, context, info)
+        return processUsers(rawValue)
+      }
+    }
+  })
+})
+```
+
 ### v3.3.5 (May 28, 2024)
 #### Fixed
 - [#532](https://github.com/join-monster/join-monster/pull/530): Updates mkdocs to 1.5.3.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 **Breaking changes:**
 
-It is no longer guaranteed that a field's value is available under `source[fieldName]` in a custom resolver. Instead, custom resolvers on non-trivial fields need to use GraphQL's default resolver to get the field value:
+It is no longer guaranteed that a field's value is available under `source[fieldName]` in a custom resolver. Instead, custom resolvers on [non-trivial fields](./warnings.md#non-trivial-fields)  need to use GraphQL's default resolver to get the field value:
 
 ```javascript
 import { defaultFieldResolver } from 'graphql'

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 **Breaking changes:**
 
-- Support querying the same fields and relations with different arguments through different aliases (fixes [#126](https://github.com/join-monster/join-monster/issues/126))
-  - It is no longer guaranteed that a field's value is available under `source[fieldName]` in a custom resolver. Instead, custom resolvers on non-trivial fields should use GraphQL's default resolver to get the raw value:
+It is no longer guaranteed that a field's value is available under `source[fieldName]` in a custom resolver. Instead, custom resolvers on non-trivial fields need to use GraphQL's default resolver to get the field value:
 
 ```javascript
 import { defaultFieldResolver } from 'graphql'
@@ -15,13 +14,18 @@ const User = new GraphQLObjectType({
     following: {
       // ...
       resolve: (source, args, context, info) => {
-        const rawValue = defaultFieldResolver(source, args, context, info)
-        return processUsers(rawValue)
+        const value = defaultFieldResolver(source, args, context, info)
+        return processUsers(value)
       }
     }
   })
 })
 ```
+
+See the [docs on custom resolvers](./warnings.md#custom-resolvers) for more details.
+
+#### Fixed
+- [#482](https://github.com/join-monster/join-monster/pull/482): Support different arguments for different aliases
 
 ### v3.3.5 (May 28, 2024)
 #### Fixed

--- a/docs/warnings.md
+++ b/docs/warnings.md
@@ -107,7 +107,7 @@ However, if there are multiple conflicting aliases accessing the same relation, 
 
 The `source.following` property is now a function that will return the correct value. GraphQL's default resolver will detect the function and do the right thing. However, passing a custom resolver will completely override GraphQL's default resolver instead of wrapping it.
 
-Therefore, it is required to get the actual value through GraphQL's default resolver first when using a custom resolver on a non-trivial field:
+Therefore, it is required to get the actual value through GraphQL's default resolver first when using a custom resolver on a [non-trivial field](#non-trivial-fields):
 
 ```javascript
 import { defaultFieldResolver } from 'graphql'
@@ -126,6 +126,8 @@ const User = new GraphQLObjectType({
   })
 })
 ```
+
+### Non-trivial Fields
 
 We currently treat fields as being "non-trivial" in the following cases:
 

--- a/src/aliases.js
+++ b/src/aliases.js
@@ -1,0 +1,51 @@
+import { isEqual } from 'lodash'
+
+// If the same field is requested through multiple aliases,
+// we modify the object shape in the following way
+// - obj[<fieldName>] => resolver function that looks up the correct key based on the alias
+// - obj[<fieldName>$<alias>] => value for alias
+// - obj[<fieldName>$] => value for access without alias
+const aliasSeparator = '$'
+
+export function getAliasKey(fieldName, alias) {
+  return fieldName + aliasSeparator + (alias || '')
+}
+
+// Types that never conflict even if they have aliases with different args.
+// That usually means the args are not used by join-monster itself.
+const neverConflictingTypes = ['noop', 'column', 'sqlDeps']
+
+// Types that always conflict even if their aliases have the same args.
+// That usually means they can have nested conflicts.
+const alwaysConflictingTypes = ['table', 'union']
+
+// Siblings are generally considered conflicting if they access the same field through different aliases.
+// As it changes the output for custom resolvers, we do our best to only mark nodes as conflicting
+// that actually need it to return the correct data.
+export function hasConflictingSiblings(node, siblings) {
+  return !neverConflictingTypes.includes(node.type)
+    && siblings.some(sibling => (
+      sibling !== node
+      && sibling.fieldName === node.fieldName
+      && sibling.alias !== node.alias
+      && !neverConflictingTypes.includes(sibling.type)
+      && (
+        alwaysConflictingTypes.includes(sibling.type)
+        // Fall back to comparing the args. This is mostly relevant for things like
+        // sqlExpr, which might use args in the query
+        || !isEqual(node.args || {}, sibling.args || {})
+      )
+    ))
+}
+
+// GraphQL's default resolver supports functions instead of values on source[fieldName],
+// and will call this function with the information required that we can
+// return the correct value for the field's alias
+export function resolveAliasValue(args, context, info) {
+  if (!info.fieldNodes || !info.fieldNodes[0]) return null
+  
+  const alias = info.fieldNodes[0].alias && info.fieldNodes[0].alias.value
+
+  // "this" is the source object that contains the aliased field values
+  return this[getAliasKey(info.fieldName, alias)]
+}

--- a/src/array-to-connection.js
+++ b/src/array-to-connection.js
@@ -1,6 +1,7 @@
 import { connectionFromArraySlice, cursorToOffset } from 'graphql-relay'
 import { objToCursor, last, sortKeyColumns } from './util'
 import idx from 'idx'
+import { getAliasKey } from './aliases'
 
 // a function for data manipulation AFTER its nested.
 // this is only necessary when using the SQL pagination
@@ -116,8 +117,16 @@ function arrToConnection(data, sqlAST) {
 export default arrToConnection
 
 function recurseOnObjInData(dataObj, astChild) {
+  const aliasKey = getAliasKey(astChild.fieldName, astChild.alias)
+  if (dataObj[aliasKey]) {
+    dataObj[aliasKey] = arrToConnection(
+      dataObj[aliasKey],
+      astChild
+    )
+  }
+
   const dataChild = dataObj[astChild.fieldName]
-  if (dataChild) {
+  if (dataChild && typeof dataChild !== 'function') {
     dataObj[astChild.fieldName] = arrToConnection(
       dataObj[astChild.fieldName],
       astChild

--- a/src/batch-planner/index.js
+++ b/src/batch-planner/index.js
@@ -142,15 +142,15 @@ async function nextBatchChild(childAST, data, dbCall, context, options, siblings
     if (childAST.paginate) {
       const targets = newData[data[parentKey]]
       data[valueKey] = arrToConnection(targets, childAST)
-      if (isConflicting) data[fieldName] = resolveAliasValue
     } else if (childAST.grabMany) {
       data[valueKey] = newData[data[parentKey]] || []
-      if (isConflicting) data[fieldName] = resolveAliasValue
     } else {
       const targets = newData[data[parentKey]] || []
       data[valueKey] = targets[0]
-      if (isConflicting) data[fieldName] = resolveAliasValue
     }
+    
+    if (isConflicting) data[fieldName] = resolveAliasValue
+    
     if (data) {
       return nextBatch(childAST, data[valueKey], dbCall, context, options)
     }

--- a/src/query-ast-to-sql-ast/index.js
+++ b/src/query-ast-to-sql-ast/index.js
@@ -523,12 +523,15 @@ function handleUnionSelections(
     // we need to figure out what kind of selection this is
     switch (selection.kind) {
       case 'Field':
+        const alias = selection.alias && selection.alias.value
+
         // has this field been requested once already? GraphQL does not protect against duplicates so we have to check for it
         const existingNode = children.find(
           child =>
             child.fieldName === selection.name.value && child.type === 'table'
+            && (child.alias && child.alias.value) === alias
         )
-        let newNode = new SQLASTNode(sqlASTNode)
+        let newNode = new SQLASTNode(sqlASTNode, { alias })
         if (existingNode) {
           newNode = existingNode
         } else {
@@ -635,12 +638,15 @@ function handleSelections(
     switch (selection.kind) {
       // if its another field, recurse through that
       case 'Field':
+        const alias = selection.alias && selection.alias.value
+
         // has this field been requested once already? GraphQL does not protect against duplicates so we have to check for it
         const existingNode = children.find(
           child =>
             child.fieldName === selection.name.value && child.type === 'table'
+            && (child.alias && child.alias.value) === alias
         )
-        let newNode = new SQLASTNode(sqlASTNode)
+        let newNode = new SQLASTNode(sqlASTNode, { alias })
         if (existingNode) {
           newNode = existingNode
         } else {

--- a/test-api/schema-basic/User.js
+++ b/test-api/schema-basic/User.js
@@ -276,6 +276,7 @@ const User = new GraphQLObjectType({
     writtenMaterial1: {
       type: new GraphQLList(AuthoredUnion),
       args: {
+        // Used to test multiple aliases with different args on unions
         search: { type: GraphQLString },
       },
       extensions: {
@@ -308,6 +309,7 @@ const User = new GraphQLObjectType({
     writtenMaterial2: {
       type: new GraphQLList(AuthoredInterface),
       args: {
+        // Used to test multiple aliases with different args on interfaces
         search: { type: GraphQLString },
       },
       extensions: {

--- a/test-api/schema-basic/User.js
+++ b/test-api/schema-basic/User.js
@@ -275,6 +275,9 @@ const User = new GraphQLObjectType({
     },
     writtenMaterial1: {
       type: new GraphQLList(AuthoredUnion),
+      args: {
+        search: { type: GraphQLString },
+      },
       extensions: {
         joinMonster: {
           orderBy: 'id',
@@ -283,20 +286,30 @@ const User = new GraphQLObjectType({
                 sqlBatch: {
                   thisKey: 'author_id',
                   parentKey: 'id'
-                }
+                },
+                where: (table, args) => {
+                  if (args.search) {
+                    return `lower(${table}.${q('body', DB)}) LIKE lower('%${args.search}%')`
+                  }
+                },
               }
             : {
-                sqlJoin: (userTable, unionTable) =>
-                  `${userTable}.${q('id', DB)} = ${unionTable}.${q(
-                    'author_id',
-                    DB
-                  )}`
+                sqlJoin: (userTable, unionTable, args) => {
+                  const joinCondition = `${userTable}.${q('id', DB)} = ${unionTable}.${q('author_id', DB)}`
+                  const filterCondition = args.search
+                    ? ` AND lower(${unionTable}.${q('body', DB)}) LIKE lower('%${args.search}%')`
+                    : ''
+                  return joinCondition + filterCondition
+                }
               })
         }
       }
     },
     writtenMaterial2: {
       type: new GraphQLList(AuthoredInterface),
+      args: {
+        search: { type: GraphQLString },
+      },
       extensions: {
         joinMonster: {
           orderBy: 'id',
@@ -305,15 +318,22 @@ const User = new GraphQLObjectType({
                 sqlBatch: {
                   thisKey: 'author_id',
                   parentKey: 'id'
-                }
+                },
+                where: (table, args) => {
+                  if (args.search) {
+                    return `lower(${table}.${q('body', DB)}) LIKE lower('%${args.search}%')`
+                  }
+                },
               }
             : {
-                sqlJoin: (userTable, unionTable) =>
-                  `${userTable}.${q('id', DB)} = ${unionTable}.${q(
-                    'author_id',
-                    DB
-                  )}`
-              })
+              sqlJoin: (userTable, unionTable, args) => {
+                const joinCondition = `${userTable}.${q('id', DB)} = ${unionTable}.${q('author_id', DB)}`
+                const filterCondition = args.search
+                  ? ` AND lower(${unionTable}.${q('body', DB)}) LIKE lower('%${args.search}%')`
+                  : ''
+                return joinCondition + filterCondition
+              }
+            })
         }
       }
     }

--- a/test/aliases.js
+++ b/test/aliases.js
@@ -1,0 +1,372 @@
+import test from 'ava'
+import { graphql } from 'graphql'
+import schema from '../test-api/schema-basic'
+import { errCheck } from './_util'
+
+test('it should resolve aliases on different nesting levels', async t => {
+  const source = `
+    query {
+      aliasedUser: user(id: 1) {
+        aliasedFullName: fullName
+        aliasedPosts: posts {
+          aliasedId: id
+          aliasedAuthor: author {
+            aliasedFullName: fullName
+          }
+        }
+        aliasedFollowing: following(name: "matt") {
+          aliasedFullName: fullName
+        }
+      }
+    }
+  `
+  const { data, errors } = await graphql({schema, source})
+  errCheck(t, errors)
+
+  t.deepEqual({
+    aliasedFullName: 'andrew carlson',
+    aliasedPosts: [
+      {
+        aliasedId: 2,
+        aliasedAuthor: {
+          aliasedFullName: 'andrew carlson'
+        }
+      }
+    ],
+    aliasedFollowing: [
+      { aliasedFullName: 'matt elder' }
+    ],
+  }, data.aliasedUser)
+})
+
+test('it should allow an alias to the same relation (without args, same fields)', async t => {
+  const source = `
+    query {
+      user(id: 3) {
+        following1: following { fullName }
+        following2: following { fullName }
+      }
+    }
+  `
+  const { data, errors } = await graphql({schema, source})
+  errCheck(t, errors)
+  t.deepEqual({
+    following1: [
+      { fullName: 'andrew carlson' },
+      { fullName: 'matt elder' }
+    ],
+    following2: [
+      { fullName: 'andrew carlson' },
+      { fullName: 'matt elder' }
+    ],
+  }, data.user)
+})
+
+test('it should handle different args nested within aliases to the same relation', async t => {
+  const source = `
+    query {
+      user(id: 3) {
+        following1: following {
+          fullName
+          comments {
+            id
+          }
+        }
+        following2: following {
+          fullName
+          comments(active: true) {
+            id
+          }
+        }
+      }
+    }
+  `
+  const { data, errors } = await graphql({schema, source})
+  errCheck(t, errors)
+  t.deepEqual({
+    following1: [
+      {
+        fullName: 'andrew carlson',
+        comments: [{ id: 1 }, { id: 4 }, { id: 6 }, { id: 8 }],
+      },
+      {
+        fullName: 'matt elder',
+        comments: [{ id: 7 }],
+      }
+    ],
+    following2: [
+      {
+        fullName: 'andrew carlson',
+        comments: [{ id: 1 }, { id: 4 }, { id: 6 }, { id: 8 }]
+      },
+      {
+        fullName: 'matt elder',
+        comments: []
+      }
+    ],
+  }, data.user)
+})
+
+test('it should allow an alias to the same relation (without args, different fields)', async t => {
+  const source = `
+    query {
+      user(id: 3) {
+        following1: following { id, fullName }
+        following2: following { fullName }
+      }
+    }
+  `
+  const { data, errors } = await graphql({schema, source})
+  errCheck(t, errors)
+  t.deepEqual({
+    following1: [
+      { id: 1, fullName: 'andrew carlson' },
+      { id: 2, fullName: 'matt elder' }
+    ],
+    following2: [
+      { fullName: 'andrew carlson' },
+      { fullName: 'matt elder' }
+    ],
+  }, data.user)
+})
+
+test('it should allow an alias to the same relation (one with args)', async t => {
+  const source = `
+    query {
+      user(id: 3) {
+        following { fullName }
+        andrews: following(name: "andrew") { fullName }
+      }
+    }
+  `
+  const { data, errors } = await graphql({schema, source})
+  errCheck(t, errors)
+  t.deepEqual({
+    following: [
+      { fullName: 'andrew carlson' },
+      { fullName: 'matt elder' }
+    ],
+    andrews: [
+      { fullName: 'andrew carlson' },
+    ]
+  }, data.user)
+})
+
+test('it should allow an alias to the same relation (both with args)', async t => {
+  const source = `
+    query {
+      user(id: 3) {
+        following(name: "matt") { fullName }
+        andrews: following(name: "andrew") { fullName }
+      }
+    }
+  `
+  const { data, errors } = await graphql({schema, source})
+  errCheck(t, errors)
+  t.deepEqual({
+    following: [
+      { fullName: 'matt elder' }
+    ],
+    andrews: [
+      { fullName: 'andrew carlson' },
+    ]
+  }, data.user)
+})
+
+test('it should allow multiple different aliases to the same relation (one with args)', async t => {
+  const source = `
+    query {
+      user(id: 3) {
+        follow: following { fullName }
+        andrews: following(name: "andrew") { fullName }
+      }
+    }
+  `
+  const { data, errors } = await graphql({schema, source})
+  errCheck(t, errors)
+  t.deepEqual({
+    follow: [
+      { fullName: 'andrew carlson' },
+      { fullName: 'matt elder' }
+    ],
+    andrews: [
+      { fullName: 'andrew carlson' },
+    ]
+  }, data.user)
+})
+
+test('it should allow multiple different aliases to the same relation (both with args)', async t => {
+  const source = `
+    query {
+      user(id: 3) {
+        matts: following(name: "matt") { fullName }
+        andrews: following(name: "andrew") { fullName }
+      }
+    }
+  `
+  const { data, errors } = await graphql({schema, source})
+  errCheck(t, errors)
+  t.deepEqual({
+    matts: [
+      { fullName: 'matt elder' }
+    ],
+    andrews: [
+      { fullName: 'andrew carlson' },
+    ]
+  }, data.user)
+})
+
+test('it should allow multiple different aliases to the same relation with args (via fragment)', async t => {
+  const source = `
+    fragment foo on User {
+      matts: following(name: "matt") { fullName }
+      andrews: following(name: "andrew") { fullName }
+    }
+    query {
+      user(id: 3) {
+        ...foo
+      }
+    }
+  `
+  const { data, errors } = await graphql({schema, source})
+  errCheck(t, errors)
+  t.deepEqual({
+    matts: [
+      { fullName: 'matt elder' }
+    ],
+    andrews: [
+      { fullName: 'andrew carlson' },
+    ]
+  }, data.user)
+})
+
+test('it should allow multiple different aliases to the same relation with args (via inline fragment)', async t => {
+  const source = `
+    query {
+      user(id: 3) {
+        ... on User {
+          matts: following(name: "matt") { fullName }
+          andrews: following(name: "andrew") { fullName }
+        }
+      }
+    }
+  `
+  const { data, errors } = await graphql({schema, source})
+  errCheck(t, errors)
+  t.deepEqual({
+    matts: [
+      { fullName: 'matt elder' }
+    ],
+    andrews: [
+      { fullName: 'andrew carlson' },
+    ]
+  }, data.user)
+})
+
+test('it should allow multiple different aliases on unions', async t => {
+  const source = `
+    query {
+      user(id: 1) {
+        libraryTexts: writtenMaterial1(search: "library") {
+          __typename
+          ... on Comment {
+            id
+            body
+          }
+          ... on Post {
+            id
+            body
+          }
+        }
+        featureTexts: writtenMaterial1(search: "feature") {
+          __typename
+          ... on Comment {
+            id
+            body
+          }
+          ... on Post {
+            id
+            body
+          }
+        }
+      }
+    }
+  `
+  const { data, errors } = await graphql({schema, source})
+  errCheck(t, errors)
+  t.deepEqual({
+    libraryTexts: [
+      {
+        __typename: 'Post',
+        id: 2,
+        body: 'Check out this cool new GraphQL library, Join Monster.'
+      },
+      {
+        __typename: 'Comment',
+        id: 8,
+        body: 'Somebody please help me with this library. It is so much work.'
+      }
+    ],
+    featureTexts: [
+      {
+        __typename: 'Comment',
+        id: 6,
+        body: 'Also, submit a PR if you have a feature you want to add.'
+      }
+    ]
+  }, data.user)
+})
+
+test('it should allow multiple different aliases on interfaces', async t => {
+  const source = `
+    query {
+      user(id: 1) {
+        libraryTexts: writtenMaterial2(search: "library") {
+          __typename
+          ... on Comment {
+            id
+            body
+          }
+          ... on Post {
+            id
+            body
+          }
+        }
+        featureTexts: writtenMaterial2(search: "feature") {
+          __typename
+          ... on Comment {
+            id
+            body
+          }
+          ... on Post {
+            id
+            body
+          }
+        }
+      }
+    }
+  `
+  const { data, errors } = await graphql({schema, source})
+  errCheck(t, errors)
+  t.deepEqual({
+    libraryTexts: [
+      {
+        __typename: 'Post',
+        id: 2,
+        body: 'Check out this cool new GraphQL library, Join Monster.'
+      },
+      {
+        __typename: 'Comment',
+        id: 8,
+        body: 'Somebody please help me with this library. It is so much work.'
+      }
+    ],
+    featureTexts: [
+      {
+        __typename: 'Comment',
+        id: 6,
+        body: 'Also, submit a PR if you have a feature you want to add.'
+      }
+    ]
+  }, data.user)
+})

--- a/test/fields.js
+++ b/test/fields.js
@@ -48,7 +48,7 @@ test('it should handle duplicate object type field', async t => {
   t.deepEqual(expect, data)
 })
 
-test.skip('it should handle duplicate object type fields with different arguments', async t => {
+test('it should handle duplicate object type fields with different arguments', async t => {
   const source = `{
     user(id: 3) {
       comments: comments(active: true) {

--- a/test/pagination/keyset-paging.js
+++ b/test/pagination/keyset-paging.js
@@ -928,3 +928,40 @@ test('should allow explicit page limit larger than default page size', async t =
   errCheck(t, errors)
   t.deepEqual(data.users.edges[0].node.comments.edges.length, 3)
 })
+
+test('can handle multiple aliases', async t => {
+  const source = `{
+    users(first: 2) {
+      edges {
+        node {
+          fullName,
+          twoPosts: posts(first: 2) {
+            edges {
+              node { body }
+            }
+          }
+          onePost: posts(first: 1) {
+            edges {
+              node { body }
+            }
+          }
+        }
+      }
+    }
+  }`
+  const { data, errors } = await graphql({schema, source})
+  errCheck(t, errors)
+  t.is(data.users.edges.length, 2)
+  t.is(data.users.edges[0].node.fullName, 'Alivia Waelchi')
+  t.is(data.users.edges[0].node.twoPosts.edges.length, 2)
+  
+  const firstPostBody = [
+    'Adipisci voluptate laborum minima sunt facilis sint quibusdam ut.',
+    'Deserunt nemo pariatur sed facere accusantium quis.',
+    'Nobis aut voluptate inventore quidem explicabo.'
+  ].join(' ')
+  t.is(data.users.edges[0].node.twoPosts.edges[0].node.body, firstPostBody)
+
+  t.is(data.users.edges[0].node.onePost.edges.length, 1)
+  t.is(data.users.edges[0].node.onePost.edges[0].node.body, firstPostBody)
+})


### PR DESCRIPTION
Hi there,

after experimenting with different workarounds in #481, I believe I may have found a proper fix for #126.

Please let me know what you think :relaxed:

I published the changes to npm as `@kryops/join-monster@3.1.1-1` if anyone wants to try it out with their schema.

### Description

The general strategy is as follows:
* `join-monster` tries to detect conflicting aliases to the same field
* If a conflict is detected, it will set multiple properties on the output object instead of overwriting the `fieldName`:

The query
```graphql
{
  users {
    following { fullName }
    matts: following(name: "matt") { fullName }
  }
}
```

generates per user:

```javascript
{
  following$: [
    { fullName: 'andrew carlson' },
    { fullName: 'matt elder' }
  ],
  following$matts: [
    { fullName: 'matt elder' }
  ],
  following: (args, context, info) => { /* ... */ }
}
```

GraphQL's default resolver supports functions as properties, and will call them with the information necessary to return the correct property.

This is a **breaking change** when using custom resolvers: Instead of always accessing `source[fieldName]`, GraphQL's `defaultFieldResolver` has to be used to get the raw value in order to support multiple conflicting aliases:

```javascript
import { defaultFieldResolver } from 'graphql'

// ...

resolve: (source, args, context, info) => {
  const rawValue = defaultFieldResolver(source, args, context, info)
  return processUsers(rawValue)
}
```

Note that this should be only actually breaking in situations that likely used to return wrong data. For normal fields and non-conflicting aliases the same format is used as before.

### References

Fixes #126

Fixes #146

### Checklist

* [x] I have added documentation for new/changed functionality in this PR via comments and by updating the change log
* [ ] I'm not entirely sure when to consider aliases as "conflicting". For now I have implemented the following logic:
  * Some types of nodes are never conflicting because `join-monster` does not use the args, thus they should point to the same data anyway (e.g. normal columns)
  * Some types of nodes are always conflicting because even using the same args, they can have nested conflicting aliases inside them (e.g. tables, unions)
  * For other types of nodes (e.g. `sqlExpr`), the args may be used by `join-monster`, so aliases are conflicting if they use different args
* [x] Are the generated property keys "unique enough"? What if a schema contains both `comments` and `comments$`?
* [x] We should probably add a separate test for aliases with paginated schemas. Maybe `Post.comments` or `User.comments`?
* [x] We should probably add a separate test for aliases with unions and interfaces. Any ideas how to best do it in the test schema? (should we add args to `writtenMaterial1` or `writtenMaterial2`?)
* [ ] I wasn't sure where to add the new behavior in the documentation. For now, I added it to the warnings page.