### PR TITLE
update to handle graphql v16_x breaking changes

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -35,7 +35,7 @@ jobs:
       matrix:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
         # node-version: [10.x, 12.x, 13.x, 14.x, 15.x]
-        node-version: [14.x, 15.x, 16.x, 17.x]
+        node-version: [14.x, 15.x, 16.x]
 
     steps:
       - name: Checkout Repo

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -21,9 +21,9 @@ name: CI Tests
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
   run-tests:
@@ -37,30 +37,40 @@ jobs:
         node-version: [10.x, 12.x, 13.x, 14.x, 15.x]
 
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v2
+      - name: Checkout Repo
+        uses: actions/checkout@v2
 
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
 
-    - name: Setup System
-      run: |
-        sudo apt-get update
-        sudo apt-get install sqlite3
+      - name: Setup System
+        run: |
+          sudo apt-get update
+          sudo apt-get install sqlite3
 
-    - name: Install Node Deps
-      run: npm ci
+      - name: Install Node Deps
+        run: npm ci
 
-    - name: Startup Databases
-      run: |
-        npm run db-up
-        echo 'Waiting for DBs to start'
-        npm run db-wait
+      - name: Startup Databases
+        run: |
+          npm run db-up
+          echo 'Waiting for DBs to start'
+          npm run db-wait
 
-    - name: Build Test Databases
-      run: npm run db-build
+      - name: Build Test Databases
+        run: npm run db-build
 
-    - name: Run Tests
-      run: npm test
+      - name: Run Tests
+        run: npm test
+
+  upload:
+    name: Upload npm logs
+    runs-on: ubuntu-latest
+    if: failure()
+    steps:
+      - uses: actions/upload-artifact@v3
+        with:
+          name: npm-logs
+          path: /home/runner/.npm/_logs/

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -34,7 +34,8 @@ jobs:
     strategy:
       matrix:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-        node-version: [10.x, 12.x, 13.x, 14.x, 15.x]
+        # node-version: [10.x, 12.x, 13.x, 14.x, 15.x]
+        node-version: [14.x, 15.x, 16.x, 17.x, 18.x]
 
     steps:
       - name: Checkout Repo

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -35,7 +35,7 @@ jobs:
       matrix:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
         # node-version: [10.x, 12.x, 13.x, 14.x, 15.x]
-        node-version: [14.x, 15.x, 16.x, 17.x, 18.x]
+        node-version: [14.x, 15.x, 16.x, 17.x]
 
     steps:
       - name: Checkout Repo

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -65,12 +65,8 @@ jobs:
       - name: Run Tests
         run: npm test
 
-  upload:
-    name: Upload npm logs
-    runs-on: ubuntu-latest
-    if: failure()
-    steps:
       - uses: actions/upload-artifact@v3
+        if: failure()
         with:
           name: npm-logs
           path: /home/runner/.npm/_logs/

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,4 @@
-### vNEXT
-
-### v3.2.0 (June 22, 2023)
+### vNEXT (June 23, 2023)
 
 #### Updated
 - [#495](https://github.com/join-monster/join-monster/pull/495): Added support for GraphQL v16_6_0. There were a number of breaking changes introduced in GraphQL v16 and these impacted a large number of tests and bit of the code. This provides fixes for those breaking changes. It also drops support for Node versions 10 - 13 but adds support for Node v16.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,9 +1,9 @@
 ### vNEXT
 
-### v3.1.2 (June 11, 2023)
+### v3.2.0 (June 22, 2023)
 
 #### Updated
-- [#495](https://github.com/join-monster/join-monster/pull/495): Added support for GraphQL v16_6_0. There were a number of breaking changes introduced in GraphQL v16 and these impacted a large number of tests and bit of the code. This provides fixes for those breaking changes.
+- [#495](https://github.com/join-monster/join-monster/pull/495): Added support for GraphQL v16_6_0. There were a number of breaking changes introduced in GraphQL v16 and these impacted a large number of tests and bit of the code. This provides fixes for those breaking changes. It also drops support for Node versions 10 - 13 but adds support for Node v16.
 
 ### v3.1.1 (January 17, 2022)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,10 @@
 ### vNEXT
 
+### v3.1.2 (June 11, 2023)
+
+#### Updated
+- [#495](https://github.com/join-monster/join-monster/pull/495): Added support for GraphQL v16_6_0. There were a number of breaking changes introduced in GraphQL v16 and these impacted a large number of tests and bit of the code. This provides fixes for those breaking changes.
+
 ### v3.1.1 (January 17, 2022)
 
 #### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -6681,7 +6681,6 @@
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -6879,8 +6878,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6970,8 +6968,7 @@
         },
         "yallist": {
           "version": "3.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -7210,14 +7207,14 @@
       "dev": true
     },
     "graphql": {
-      "version": "15.4.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.4.0.tgz",
-      "integrity": "sha512-EB3zgGchcabbsU9cFe1j+yxdzKQKAbGUWRb13DsrsMN1yyfmmIq+2+L5MqVWcDCE4V89R5AyUOi7sMOGxdsYtA==",
+      "version": "16.6.0",
+      "resolved": "https://amazon-149122183214.d.codeartifact.us-west-2.amazonaws.com/npm/music-sonic/graphql/-/graphql-16.6.0.tgz",
+      "integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==",
       "dev": true
     },
     "graphql-relay": {
       "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/graphql-relay/-/graphql-relay-0.6.0.tgz",
+      "resolved": "https://amazon-149122183214.d.codeartifact.us-west-2.amazonaws.com/npm/music-sonic/graphql-relay/-/graphql-relay-0.6.0.tgz",
       "integrity": "sha512-OVDi6C9/qOT542Q3KxZdXja3NrDvqzbihn1B44PH8P/c5s0Q90RyQwT6guhGqXqbYEH6zbeLJWjQqiYvcg2vVw==",
       "requires": {
         "prettier": "^1.16.0"
@@ -10246,7 +10243,7 @@
     },
     "prettier": {
       "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
+      "resolved": "https://amazon-149122183214.d.codeartifact.us-west-2.amazonaws.com/npm/music-sonic/prettier/-/prettier-1.19.1.tgz",
       "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew=="
     },
     "pretty-ms": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3059,6 +3059,15 @@
       "integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==",
       "dev": true
     },
+    "@jest/schemas": {
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.4.3.tgz",
+      "integrity": "sha512-VLYKXQmtmuEz6IxJsrZwzG9NvtkQsWNnWMsKxqWNu3+CnfzJQhp0WDDKWLVV9hLKr0l3SLLFRqcYHjhtyuDVxg==",
+      "dev": true,
+      "requires": {
+        "@sinclair/typebox": "^0.25.16"
+      }
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
@@ -3084,6 +3093,12 @@
         "@nodelib/fs.scandir": "2.1.3",
         "fastq": "^1.6.0"
       }
+    },
+    "@sinclair/typebox": {
+      "version": "0.25.24",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.25.24.tgz",
+      "integrity": "sha512-XJfwUVUKDHF5ugKwIcxEgc9k8b7HbznCp6eUfWgu710hMPNIO4aw4/zB5RogDQz8nd6gyCDpU9O/m6qYEWY6yQ==",
+      "dev": true
     },
     "@sindresorhus/is": {
       "version": "0.14.0",
@@ -3160,10 +3175,32 @@
         "defer-to-connect": "^1.0.1"
       }
     },
+    "@tsd/typescript": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@tsd/typescript/-/typescript-5.0.4.tgz",
+      "integrity": "sha512-YQi2lvZSI+xidKeUjlbv6b6Zw7qB3aXHw5oGJLs5OOGAEqKIOvz5UIAkWyg0bJbkSUWPBEtaOHpVxU4EYBO1Jg==",
+      "dev": true
+    },
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
+      "dev": true
+    },
+    "@types/eslint": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.29.0.tgz",
+      "integrity": "sha512-VNcvioYDH8/FxaeTKkM4/TiTwt6pBV9E3OfGmvaw8tPl0rrHCJ4Ll15HRT+pMiFAf/MLQvAzC+6RzUMEL9Ceng==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "*",
+        "@types/json-schema": "*"
+      }
+    },
+    "@types/estree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.1.tgz",
+      "integrity": "sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==",
       "dev": true
     },
     "@types/glob": {
@@ -3176,6 +3213,12 @@
         "@types/node": "*"
       }
     },
+    "@types/json-schema": {
+      "version": "7.0.12",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
+      "integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==",
+      "dev": true
+    },
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -3183,9 +3226,9 @@
       "dev": true
     },
     "@types/minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY=",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
+      "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
       "dev": true
     },
     "@types/node": {
@@ -4896,9 +4939,9 @@
       "dev": true
     },
     "decamelize-keys": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
-      "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.1.tgz",
+      "integrity": "sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==",
       "dev": true,
       "requires": {
         "decamelize": "^1.1.0",
@@ -4908,7 +4951,7 @@
         "map-obj": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-          "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+          "integrity": "sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==",
           "dev": true
         }
       }
@@ -5166,6 +5209,12 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true
+    },
+    "diff-sequences": {
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.4.3.tgz",
+      "integrity": "sha512-ofrBgwpPhCD85kMKtE9RYFFq6OC1A89oW2vvgWZNCwxrUpRUILopY7lsYyMDSjc8g6U6aiO0Qubg6r4Wgt5ZnA==",
       "dev": true
     },
     "dir-glob": {
@@ -5535,11 +5584,12 @@
       }
     },
     "eslint-formatter-pretty": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-formatter-pretty/-/eslint-formatter-pretty-4.0.0.tgz",
-      "integrity": "sha512-QgdeZxQwWcN0TcXXNZJiS6BizhAANFhCzkE7Yl9HKB7WjElzwED6+FbbZB2gji8ofgJTGPqKm6VRCNT3OGCeEw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-formatter-pretty/-/eslint-formatter-pretty-4.1.0.tgz",
+      "integrity": "sha512-IsUTtGxF1hrH6lMWiSl1WbGaiP01eT6kzywdY1U+zLc0MP+nwEnUiS9UI8IaOTUhTeQJLlCEWIbXINBH4YJbBQ==",
       "dev": true,
       "requires": {
+        "@types/eslint": "^7.2.13",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.1.0",
         "eslint-rule-docs": "^1.1.5",
@@ -5550,19 +5600,18 @@
       },
       "dependencies": {
         "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
           "requires": {
-            "@types/color-name": "^1.1.1",
             "color-convert": "^2.0.1"
           }
         },
         "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -5585,18 +5634,19 @@
           "dev": true
         },
         "log-symbols": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
-          "integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+          "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
           "dev": true,
           "requires": {
-            "chalk": "^4.0.0"
+            "chalk": "^4.1.0",
+            "is-unicode-supported": "^0.1.0"
           }
         },
         "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
@@ -5605,9 +5655,9 @@
       }
     },
     "eslint-rule-docs": {
-      "version": "1.1.201",
-      "resolved": "https://registry.npmjs.org/eslint-rule-docs/-/eslint-rule-docs-1.1.201.tgz",
-      "integrity": "sha512-HS327MkM3ebCcjAQMkhNYZbN/4Eu/NO5ipDK8uNVPqUrAPRUsXkuuEfE+DEx4YItkszKp4ND1F3hN8BwfXdx0w==",
+      "version": "1.1.235",
+      "resolved": "https://registry.npmjs.org/eslint-rule-docs/-/eslint-rule-docs-1.1.235.tgz",
+      "integrity": "sha512-+TQ+x4JdTnDoFEXXb3fDvfGOwnyNV7duH8fXWTPD1ieaBmB8omj7Gw/pMBBu4uI2uJCCU8APDaQJzWuXnTsH4A==",
       "dev": true
     },
     "eslint-scope": {
@@ -7678,6 +7728,15 @@
         "ci-info": "^2.0.0"
       }
     },
+    "is-core-module": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.1.tgz",
+      "integrity": "sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3"
+      }
+    },
     "is-data-descriptor": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
@@ -7818,7 +7877,7 @@
     "is-plain-obj": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+      "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
       "dev": true
     },
     "is-plain-object": {
@@ -7897,6 +7956,12 @@
       "requires": {
         "unc-path-regex": "^0.1.2"
       }
+    },
+    "is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true
     },
     "is-url": {
       "version": "1.2.4",
@@ -8093,6 +8158,69 @@
         "html-escaper": "^2.0.0",
         "istanbul-lib-report": "^3.0.0"
       }
+    },
+    "jest-diff": {
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.5.0.tgz",
+      "integrity": "sha512-LtxijLLZBduXnHSniy0WMdaHjmQnt3g5sa16W4p0HqukYTTsyTW3GD1q41TyGl5YFXj/5B2U6dlh5FM1LIMgxw==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^29.4.3",
+        "jest-get-type": "^29.4.3",
+        "pretty-format": "^29.5.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-get-type": {
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.4.3.tgz",
+      "integrity": "sha512-J5Xez4nRRMjk8emnTpWrlkyb9pfRQQanDrvWHhsR1+VUfbwxi30eVcZFlcdGInRibU4G5LwHXpI7IRHU0CY+gg==",
+      "dev": true
     },
     "js-string-escape": {
       "version": "1.0.1",
@@ -8741,6 +8869,23 @@
       "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
       "dev": true
     },
+    "lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "requires": {
+        "yallist": "^4.0.0"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
+      }
+    },
     "make-dir": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
@@ -8784,9 +8929,9 @@
       "dev": true
     },
     "map-obj": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.1.0.tgz",
-      "integrity": "sha512-glc9y00wgtwcDmp7GaE/0b0OnxpNJsVf3ael/An6Fe2Q51LLwN1er6sdomLRzz5h0+yMpiYLhWYF5R7HeqVd4g==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
+      "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
       "dev": true
     },
     "map-visit": {
@@ -8892,36 +9037,65 @@
       }
     },
     "meow": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-7.0.1.tgz",
-      "integrity": "sha512-tBKIQqVrAHqwit0vfuFPY3LlzJYkEOFyKa3bPgxzNl6q/RtN8KQ+ALYEASYuFayzSAsjlhXj/JZ10rH85Q6TUw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-9.0.0.tgz",
+      "integrity": "sha512-+obSblOQmRhcyBt62furQqRAQpNyWXo8BuQ5bN7dG8wmwQ+vwHKp/rCFD4CrTP8CsDQD1sjoZ94K417XEUk8IQ==",
       "dev": true,
       "requires": {
         "@types/minimist": "^1.2.0",
-        "arrify": "^2.0.1",
-        "camelcase": "^6.0.0",
         "camelcase-keys": "^6.2.2",
+        "decamelize": "^1.2.0",
         "decamelize-keys": "^1.1.0",
         "hard-rejection": "^2.1.0",
-        "minimist-options": "^4.0.2",
-        "normalize-package-data": "^2.5.0",
+        "minimist-options": "4.1.0",
+        "normalize-package-data": "^3.0.0",
         "read-pkg-up": "^7.0.1",
         "redent": "^3.0.0",
         "trim-newlines": "^3.0.0",
-        "type-fest": "^0.13.1",
-        "yargs-parser": "^18.1.3"
+        "type-fest": "^0.18.0",
+        "yargs-parser": "^20.2.3"
       },
       "dependencies": {
-        "camelcase": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.0.0.tgz",
-          "integrity": "sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w==",
-          "dev": true
+        "hosted-git-info": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+          "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "normalize-package-data": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+          "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "^4.0.1",
+            "is-core-module": "^2.5.0",
+            "semver": "^7.3.4",
+            "validate-npm-package-license": "^3.0.1"
+          }
+        },
+        "semver": {
+          "version": "7.5.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.2.tgz",
+          "integrity": "sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
         },
         "type-fest": {
-          "version": "0.13.1",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
-          "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+          "version": "0.18.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
+          "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
+          "dev": true
+        },
+        "yargs-parser": {
+          "version": "20.2.9",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+          "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
           "dev": true
         }
       }
@@ -9021,7 +9195,7 @@
         "arrify": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-          "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+          "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
           "dev": true
         },
         "kind-of": {
@@ -10243,8 +10417,27 @@
     },
     "prettier": {
       "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
+      "resolved": "https://amazon-149122183214.d.codeartifact.us-west-2.amazonaws.com/npm/music-sonic/prettier/-/prettier-1.19.1.tgz",
       "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew=="
+    },
+    "pretty-format": {
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.5.0.tgz",
+      "integrity": "sha512-V2mGkI31qdttvTFX7Mt4efOqHXqJWMu4/r66Xh3Z3BwZaPfPJgp6/gbwoujRpPUtfEF6AUUWx3Jim3GCw5g/Qw==",
+      "dev": true,
+      "requires": {
+        "@jest/schemas": "^29.4.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+          "dev": true
+        }
+      }
     },
     "pretty-ms": {
       "version": "7.0.0",
@@ -10361,6 +10554,12 @@
         "minimist": "^1.2.0",
         "strip-json-comments": "~2.0.1"
       }
+    },
+    "react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+      "dev": true
     },
     "read-pkg": {
       "version": "5.2.0",
@@ -11877,9 +12076,9 @@
       }
     },
     "supports-hyperlinks": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.1.0.tgz",
-      "integrity": "sha512-zoE5/e+dnEijk6ASB6/qrK+oYdm2do1hjoLWrqUC/8WEIW1gbxFcKuBof7sW8ArN6e+AYvsE8HBGiVRWL/F5CA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz",
+      "integrity": "sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==",
       "dev": true,
       "requires": {
         "has-flag": "^4.0.0",
@@ -11887,9 +12086,9 @@
       },
       "dependencies": {
         "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
@@ -12187,17 +12386,18 @@
       "dev": true
     },
     "tsd": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/tsd/-/tsd-0.13.1.tgz",
-      "integrity": "sha512-+UYM8LRG/M4H8ISTg2ow8SWi65PS7Os+4DUnyiQLbJysXBp2DEmws9SMgBH+m8zHcJZqUJQ+mtDWJXP1IAvB2A==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/tsd/-/tsd-0.28.1.tgz",
+      "integrity": "sha512-FeYrfJ05QgEMW/qOukNCr4fAJHww4SaKnivAXRv4g5kj4FeLpNV7zH4dorzB9zAfVX4wmA7zWu/wQf7kkcvfbw==",
       "dev": true,
       "requires": {
-        "eslint-formatter-pretty": "^4.0.0",
+        "@tsd/typescript": "~5.0.2",
+        "eslint-formatter-pretty": "^4.1.0",
         "globby": "^11.0.1",
-        "meow": "^7.0.1",
+        "jest-diff": "^29.0.3",
+        "meow": "^9.0.0",
         "path-exists": "^4.0.0",
-        "read-pkg-up": "^7.0.0",
-        "update-notifier": "^4.1.0"
+        "read-pkg-up": "^7.0.0"
       },
       "dependencies": {
         "path-exists": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7208,13 +7208,13 @@
     },
     "graphql": {
       "version": "16.6.0",
-      "resolved": "https://amazon-149122183214.d.codeartifact.us-west-2.amazonaws.com/npm/music-sonic/graphql/-/graphql-16.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.6.0.tgz",
       "integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==",
       "dev": true
     },
     "graphql-relay": {
       "version": "0.6.0",
-      "resolved": "https://amazon-149122183214.d.codeartifact.us-west-2.amazonaws.com/npm/music-sonic/graphql-relay/-/graphql-relay-0.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/graphql-relay/-/graphql-relay-0.6.0.tgz",
       "integrity": "sha512-OVDi6C9/qOT542Q3KxZdXja3NrDvqzbihn1B44PH8P/c5s0Q90RyQwT6guhGqXqbYEH6zbeLJWjQqiYvcg2vVw==",
       "requires": {
         "prettier": "^1.16.0"
@@ -10243,7 +10243,7 @@
     },
     "prettier": {
       "version": "1.19.1",
-      "resolved": "https://amazon-149122183214.d.codeartifact.us-west-2.amazonaws.com/npm/music-sonic/prettier/-/prettier-1.19.1.tgz",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
       "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew=="
     },
     "pretty-ms": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10417,7 +10417,7 @@
     },
     "prettier": {
       "version": "1.19.1",
-      "resolved": "https://amazon-149122183214.d.codeartifact.us-west-2.amazonaws.com/npm/music-sonic/prettier/-/prettier-1.19.1.tgz",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
       "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew=="
     },
     "pretty-format": {

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
   },
   "homepage": "https://github.com/join-monster/join-monster#readme",
   "peerDependencies": {
-    "graphql": "^16.6.0|^15.4.0"
+    "graphql": "^16.0.0|^15.4.0"
   },
   "devDependencies": {
     "@ava/babel": "^1.0.1",
@@ -97,7 +97,7 @@
     "eslint-config-airbnb-base": "^14.1.0",
     "eslint-config-prettier": "^6.11.0",
     "faker": "^4.1.0",
-    "graphql": "^15.4.0",
+    "graphql": "^16.6.0",
     "graphsiql": "0.2.0",
     "idx": "^2.5.6",
     "jsdoc-to-markdown": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
   },
   "homepage": "https://github.com/join-monster/join-monster#readme",
   "peerDependencies": {
-    "graphql": "^15.4.0"
+    "graphql": "^16.6.0"
   },
   "devDependencies": {
     "@ava/babel": "^1.0.1",
@@ -97,7 +97,7 @@
     "eslint-config-airbnb-base": "^14.1.0",
     "eslint-config-prettier": "^6.11.0",
     "faker": "^4.1.0",
-    "graphql": "^15.4.0",
+    "graphql": "^16.6.0",
     "graphsiql": "0.2.0",
     "idx": "^2.5.6",
     "jsdoc-to-markdown": "^5.0.0",
@@ -120,7 +120,7 @@
     "debug": "^4.1.0",
     "deprecate": "^1.0.0",
     "generatorics": "^1.0.8",
-    "graphql-relay": "^0.6.0",
+    "graphql-relay": "^0.10.0",
     "lodash": "^4.17.15"
   }
 }

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
   },
   "homepage": "https://github.com/join-monster/join-monster#readme",
   "peerDependencies": {
-    "graphql": "^16.6.0"
+    "graphql": "^16.6.0|^15.4.0"
   },
   "devDependencies": {
     "@ava/babel": "^1.0.1",
@@ -97,7 +97,7 @@
     "eslint-config-airbnb-base": "^14.1.0",
     "eslint-config-prettier": "^6.11.0",
     "faker": "^4.1.0",
-    "graphql": "^16.6.0",
+    "graphql": "^15.4.0",
     "graphsiql": "0.2.0",
     "idx": "^2.5.6",
     "jsdoc-to-markdown": "^5.0.0",
@@ -120,7 +120,7 @@
     "debug": "^4.1.0",
     "deprecate": "^1.0.0",
     "generatorics": "^1.0.8",
-    "graphql-relay": "^0.10.0",
+    "graphql-relay": "^0.6.0",
     "lodash": "^4.17.15"
   }
 }

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "pg": "^8.2.1",
     "sinon": "^9.0.2",
     "sqlite3": "^4.2.0",
-    "tsd": "^0.13.1"
+    "tsd": "^0.28.1"
   },
   "dependencies": {
     "@stem/nesthydrationjs": "0.4.0",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,7 +1,9 @@
-import * as graphql from 'graphql'
+// import * as graphql from 'graphql'
 export type Maybe<T> = null | undefined | T
 
 // Extend graphql objects and fields
+
+export type TArgs = { [argName: string]: any }
 
 export type SqlJoin<TContext, TArgs> = (
   table1: string,
@@ -27,7 +29,7 @@ export type OrderBy =
 export type SortKey =
   | { column: string; direction: Direction }[]
   | {
-      order: Direction
+      order: Direction,
       key: string | string[]
     } // this is the old, pre 3.0 style limited to one direction for many keys
 
@@ -36,75 +38,75 @@ export type ThunkWithArgsCtx<T, TContext, TArgs> =
   | T
 
 export interface ObjectTypeExtension<TSource, TContext> {
-  alwaysFetch?: string | string[]
-  sqlTable?: ThunkWithArgsCtx<string, TContext, any>
+  alwaysFetch?: string | string[],
+  sqlTable?: ThunkWithArgsCtx<string, TContext, any>,
   uniqueKey?: string | string[]
 }
 
 export interface FieldConfigExtension<TSource, TContext, TArgs> {
-  ignoreAll?: boolean
-  ignoreTable?: boolean
+  ignoreAll?: boolean,
+  ignoreTable?: boolean,
   junction?: {
     include?: ThunkWithArgsCtx<
       {
         [column: string]: {
-          sqlColumn?: string
-          sqlExpr?: string
+          sqlColumn?: string,
+          sqlExpr?: string,
           sqlDeps?: string | string[]
         }
       },
       TContext,
       TArgs
-    >
-    orderBy?: ThunkWithArgsCtx<OrderBy, TContext, TArgs>
-    sortKey?: ThunkWithArgsCtx<SortKey, TContext, TArgs>
+    >,
+    orderBy?: ThunkWithArgsCtx<OrderBy, TContext, TArgs>,
+    sortKey?: ThunkWithArgsCtx<SortKey, TContext, TArgs>,
     sqlBatch?: {
-      thisKey: string
-      parentKey: string
+      thisKey: string,
+      parentKey: string,
       sqlJoin: SqlJoin<TContext, TArgs>
-    }
-    sqlJoins?: [SqlJoin<TContext, TArgs>, SqlJoin<TContext, TArgs>]
-    sqlTable: ThunkWithArgsCtx<string, TContext, TArgs>
-    uniqueKey?: string | string[]
+    },
+    sqlJoins?: [SqlJoin<TContext, TArgs>, SqlJoin<TContext, TArgs>],
+    sqlTable: ThunkWithArgsCtx<string, TContext, TArgs>,
+    uniqueKey?: string | string[],
     where?: Where<TContext, TArgs>
-  }
-  limit?: ThunkWithArgsCtx<number, TContext, TArgs>
-  orderBy?: ThunkWithArgsCtx<OrderBy, TContext, TArgs>
-  sortKey?: ThunkWithArgsCtx<SortKey, TContext, TArgs>
+  },
+  limit?: ThunkWithArgsCtx<number, TContext, TArgs>,
+  orderBy?: ThunkWithArgsCtx<OrderBy, TContext, TArgs>,
+  sortKey?: ThunkWithArgsCtx<SortKey, TContext, TArgs>,
   sqlBatch?: {
-    thisKey: string
+    thisKey: string,
     parentKey: string
-  }
-  sqlColumn?: string
-  sqlDeps?: string[]
+  },
+  sqlColumn?: string,
+  sqlDeps?: string[],
   sqlExpr?: (
     table: string,
     args: TArgs,
     context: TContext,
     sqlASTNode: any
-  ) => string
-  sqlJoin?: SqlJoin<TContext, TArgs>
-  sqlPaginate?: boolean
-  sqlPageLimit?: number
-  sqlDefaultPageSize?: number
+  ) => string,
+  sqlJoin?: SqlJoin<TContext, TArgs>,
+  sqlPaginate?: boolean,
+  sqlPageLimit?: number,
+  sqlDefaultPageSize?: number,
   where?: Where<TContext, TArgs>
 }
 
 export interface UnionTypeExtension {
-  sqlTable?: ThunkWithArgsCtx<string, any, any>
-  uniqueKey?: string | string[]
+  sqlTable?: ThunkWithArgsCtx<string, any, TArgs>,
+  uniqueKey?: string | string[],
   alwaysFetch?: string | string[]
 }
 
 export interface InterfaceTypeExtension {
-  sqlTable?: ThunkWithArgsCtx<string, any, any>
-  uniqueKey?: string | string[]
+  sqlTable?: ThunkWithArgsCtx<string, any, TArgs>,
+  uniqueKey?: string | string[],
   alwaysFetch?: string | string[]
 }
 
 export interface ScalarTypeExtension {
-  sqlTable?: ThunkWithArgsCtx<string, any, any>
-  uniqueKey?: string | string[]
+  sqlTable?: ThunkWithArgsCtx<string, any, TArgs>,
+  uniqueKey?: string | string[],
   alwaysFetch?: string | string[]
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -153,7 +153,7 @@ async function getNode(
       node: {
         type,
         name: type.name.toLowerCase(),
-        args: {},
+        args: [],
         extensions: {
           joinMonster: {
             where
@@ -184,7 +184,7 @@ async function getNode(
   )
   await nextBatch(sqlAST, data, dbCall, context, options)
   if (!data) return data
-  data.__type__ = type
+  data.__type__ = type.name
   return data
 }
 

--- a/test-api/schema-paginated/User.js
+++ b/test-api/schema-paginated/User.js
@@ -478,7 +478,7 @@ const User = new GraphQLObjectType({
   })
 })
 
-const connectionConfig = { nodeType: GraphQLNonNull(User) }
+const connectionConfig = { nodeType: new GraphQLNonNull(User) }
 if (PAGINATE === 'offset') {
   connectionConfig.connectionFields = {
     total: { type: GraphQLInt }

--- a/test-d/index.test-d.ts
+++ b/test-d/index.test-d.ts
@@ -1,14 +1,12 @@
 import { expectType } from 'tsd'
-import joinMonster from '..'
 import { GraphQLObjectType, GraphQLList } from 'graphql'
 
 type ExampleContext = {
   foo: 'bar'
 }
 type ExampleArgs = { [key: string]: any }
-
 // test table level extensions
-const User = new GraphQLObjectType({
+let User = new GraphQLObjectType({
   name: 'User',
   extensions: {
     joinMonster: {
@@ -21,12 +19,12 @@ const User = new GraphQLObjectType({
 })
 
 // test sqlTable thunk
-new GraphQLObjectType<any, ExampleContext>({
+User = new GraphQLObjectType<any, ExampleContext>({
   name: 'User',
   extensions: {
     joinMonster: {
-      sqlTable: (args, context) => {
-        expectType<any>(args)
+      sqlTable: (args: ExampleArgs, context: ExampleContext) => {
+        expectType<ExampleArgs>(args)
         expectType<ExampleContext>(context)
         return 'expr'
       }
@@ -36,7 +34,7 @@ new GraphQLObjectType<any, ExampleContext>({
 })
 
 // test field extensions
-new GraphQLObjectType<any, ExampleContext>({
+User = new GraphQLObjectType<any, ExampleContext>({
   name: 'User',
   fields: () => ({
     following: {
@@ -60,13 +58,13 @@ new GraphQLObjectType<any, ExampleContext>({
           },
           sqlColumn: 'foo',
           sqlDeps: ['bar', 'baz'],
-          sqlExpr: (table, args, context) => {
+          sqlExpr: (table: string, args: ExampleArgs, context: ExampleContext) => {
             expectType<string>(table)
             expectType<ExampleArgs>(args)
             expectType<ExampleContext>(context)
             return 'expr'
           },
-          sqlJoin: (table1, table2, args, context) => {
+          sqlJoin: (table1: string, table2: string, args: ExampleArgs, context: ExampleContext) => {
             expectType<string>(table1)
             expectType<string>(table2)
             expectType<ExampleArgs>(args)
@@ -74,7 +72,7 @@ new GraphQLObjectType<any, ExampleContext>({
             return 'foo'
           },
           sqlPaginate: true,
-          where: (table, args, context) => {
+          where: (table:string, args: ExampleArgs, context: ExampleContext) => {
             expectType<string>(table)
             expectType<ExampleArgs>(args)
             expectType<ExampleContext>(context)
@@ -87,19 +85,19 @@ new GraphQLObjectType<any, ExampleContext>({
 })
 
 // test thunked field extensions
-new GraphQLObjectType<any, ExampleContext>({
+User = new GraphQLObjectType<any, ExampleContext>({
   name: 'User',
   fields: () => ({
     following: {
       type: new GraphQLList(User),
       extensions: {
         joinMonster: {
-          limit: (args, context) => {
+          limit: (args: ExampleArgs, context: ExampleContext) => {
             expectType<ExampleArgs>(args)
             expectType<ExampleContext>(context)
             return 10
           },
-          orderBy: (args, context) => {
+          orderBy: (args: ExampleArgs, context: ExampleContext) => {
             expectType<ExampleArgs>(args)
             expectType<ExampleContext>(context)
             return [
@@ -107,7 +105,7 @@ new GraphQLObjectType<any, ExampleContext>({
               { column: 'bar', direction: 'DESC' }
             ]
           },
-          sortKey: (args, context) => {
+          sortKey: (args: ExampleArgs, context: ExampleContext) => {
             expectType<ExampleArgs>(args)
             expectType<ExampleContext>(context)
             return [
@@ -124,14 +122,14 @@ new GraphQLObjectType<any, ExampleContext>({
 })
 
 // test junction includes
-new GraphQLObjectType<any, ExampleContext>({
+User = new GraphQLObjectType<any, ExampleContext>({
   name: 'User',
   fields: () => ({
     following: {
       type: new GraphQLList(User),
       extensions: {
         joinMonster: {
-          where: accountTable => `${accountTable}.is_active = TRUE`,
+          where: (accountTable: string) => `${accountTable}.is_active = TRUE`,
           junction: {
             sqlTable: 'relationships',
             orderBy: {
@@ -145,7 +143,7 @@ new GraphQLObjectType<any, ExampleContext>({
             sqlBatch: {
               thisKey: 'foo',
               parentKey: 'bar',
-              sqlJoin: (table1, table2, args, context) => {
+              sqlJoin: (table1: string, table2: string) => {
                 expectType<string>(table1)
                 expectType<string>(table2)
 
@@ -158,14 +156,14 @@ new GraphQLObjectType<any, ExampleContext>({
               }
             },
             sqlJoins: [
-              (followerTable, junctionTable, args, context) => {
+              (followerTable: string, junctionTable: string, args: ExampleArgs, context: ExampleContext) => {
                 expectType<string>(followerTable)
                 expectType<string>(junctionTable)
                 expectType<ExampleArgs>(args)
                 expectType<ExampleContext>(context)
                 return `${followerTable}.id = ${junctionTable}.follower_id`
               },
-              (junctionTable, followeeTable, args, context) => {
+              (junctionTable: string, followeeTable: string, args: ExampleArgs, context: ExampleContext) => {
                 expectType<string>(followeeTable)
                 expectType<string>(junctionTable)
                 expectType<ExampleArgs>(args)
@@ -181,21 +179,21 @@ new GraphQLObjectType<any, ExampleContext>({
 })
 
 // test thunked junction includes
-new GraphQLObjectType<any, ExampleContext>({
+User = new GraphQLObjectType<any, ExampleContext>({
   name: 'User',
   fields: () => ({
     following: {
       type: new GraphQLList(User),
       extensions: {
         joinMonster: {
-          where: accountTable => `${accountTable}.is_active = TRUE`,
+          where: (accountTable: string) => `${accountTable}.is_active = TRUE`,
           junction: {
-            sqlTable: (args, context) => {
+            sqlTable: (args: ExampleArgs, context: ExampleContext) => {
               expectType<ExampleArgs>(args)
               expectType<ExampleContext>(context)
               return 'relationships'
             },
-            orderBy: (args, context) => {
+            orderBy: (args: ExampleArgs, context: ExampleContext) => {
               expectType<ExampleArgs>(args)
               expectType<ExampleContext>(context)
               return {
@@ -203,7 +201,7 @@ new GraphQLObjectType<any, ExampleContext>({
                 bar: 'DESC'
               }
             },
-            sortKey: (args, context) => {
+            sortKey: (args: ExampleArgs, context: ExampleContext) => {
               expectType<ExampleArgs>(args)
               expectType<ExampleContext>(context)
               return {
@@ -211,7 +209,7 @@ new GraphQLObjectType<any, ExampleContext>({
                 key: ['id']
               }
             },
-            include: (args, context) => {
+            include: (args: ExampleArgs, context: ExampleContext) => {
               expectType<ExampleArgs>(args)
               expectType<ExampleContext>(context)
 
@@ -221,7 +219,7 @@ new GraphQLObjectType<any, ExampleContext>({
                 }
               }
             },
-            where: (junctionTable, args, context) => {
+            where: (junctionTable: string, args: ExampleArgs, context: ExampleContext) => {
               expectType<string>(junctionTable)
               expectType<ExampleArgs>(args)
               expectType<ExampleContext>(context)

--- a/test/fields.js
+++ b/test/fields.js
@@ -1,19 +1,17 @@
 import test from 'ava'
 import { graphql } from 'graphql'
-import schemaBasic from '../test-api/schema-basic/index'
-import { partial } from 'lodash'
+import schema from '../test-api/schema-basic/index'
 import { errCheck } from './_util'
 
-const run = partial(graphql, schemaBasic)
 
 test('it should handle duplicate scalar field', async t => {
-  const query = `{
+  const source = `{
     user(id: 1) {
       fullName
       fullName
     }
   }`
-  const { data, errors } = await run(query)
+  const { data, errors } = await graphql({schema, source})
   errCheck(t, errors)
   const expect = {
     user: {
@@ -24,7 +22,7 @@ test('it should handle duplicate scalar field', async t => {
 })
 
 test('it should handle duplicate object type field', async t => {
-  const query = `{
+  const source = `{
     user(id: 1) {
       posts {
         body
@@ -35,7 +33,7 @@ test('it should handle duplicate object type field', async t => {
       }
     }
   }`
-  const { data, errors } = await run(query)
+  const { data, errors } = await graphql({schema, source})
   errCheck(t, errors)
   const expect = {
     user: {
@@ -51,7 +49,7 @@ test('it should handle duplicate object type field', async t => {
 })
 
 test.skip('it should handle duplicate object type fields with different arguments', async t => {
-  const query = `{
+  const source = `{
     user(id: 3) {
       comments: comments(active: true) {
         id
@@ -61,7 +59,7 @@ test.skip('it should handle duplicate object type fields with different argument
       }
     }
   }`
-  const { data, errors } = await run(query)
+  const { data, errors } = await graphql({schema, source})
   errCheck(t, errors)
   const expect = {
     user: {
@@ -73,7 +71,7 @@ test.skip('it should handle duplicate object type fields with different argument
 })
 
 test('it should handle duplicate of a field off the query root', async t => {
-  const query = `{
+  const source = `{
     user(id: 1) {
       fullName
     }
@@ -81,7 +79,7 @@ test('it should handle duplicate of a field off the query root', async t => {
       email
     }
   }`
-  const { data, errors } = await run(query)
+  const { data, errors } = await graphql({schema, source})
   errCheck(t, errors)
   const expect = {
     fullName: 'andrew carlson',
@@ -91,7 +89,7 @@ test('it should handle duplicate of a field off the query root', async t => {
 })
 
 test('it should handle duplicate of a field off the query root with aliases', async t => {
-  const query = `{
+  const source = `{
     thing1: user(id: 1) {
       fullName
     }
@@ -99,7 +97,7 @@ test('it should handle duplicate of a field off the query root with aliases', as
       email
     }
   }`
-  const { data, errors } = await run(query)
+  const { data, errors } = await graphql({schema, source})
   errCheck(t, errors)
   const expect = {
     thing1: {
@@ -113,7 +111,7 @@ test('it should handle duplicate of a field off the query root with aliases', as
 })
 
 test('it should handle duplicate of a field recursively', async t => {
-  const query = `{
+  const source = `{
     user(id: 2) {
       fullName
       posts {
@@ -131,7 +129,7 @@ test('it should handle duplicate of a field recursively', async t => {
       }
     }
   }`
-  const { data, errors } = await run(query)
+  const { data, errors } = await graphql({schema, source})
   errCheck(t, errors)
   const expect = {
     fullName: 'matt elder',

--- a/test/filteringInNestedBatches.js
+++ b/test/filteringInNestedBatches.js
@@ -1,13 +1,11 @@
 import test from 'ava'
 import { graphql } from 'graphql'
-import schemaBasic from '../test-api/schema-basic/index'
-import { partial } from 'lodash'
+import schema from '../test-api/schema-basic/index'
 import { errCheck } from './_util'
 
-const run = partial(graphql, schemaBasic)
 
 test('it should get user 1 with comments and particular posts', async t => {
-  const query = ` {
+  const source = ` {
     user(id: 1) {
       comments {
         id
@@ -19,7 +17,7 @@ test('it should get user 1 with comments and particular posts', async t => {
       }
     }
   }`
-  const { data, errors } = await run(query)
+  const { data, errors } = await graphql({schema, source})
   errCheck(t, errors)
   const expect = {
     user: {
@@ -56,7 +54,7 @@ test('it should get user 1 with comments and particular posts', async t => {
 })
 
 test('it should get user 1 with comments and particular posts with active comments', async t => {
-  const query = `{
+  const source = `{
     user(id: 1) {
       comments {
         id
@@ -68,7 +66,7 @@ test('it should get user 1 with comments and particular posts with active commen
       }
     }
   }`
-  const { data, errors } = await run(query)
+  const { data, errors } = await graphql({schema, source})
   errCheck(t, errors)
   const expect = {
     user: {

--- a/test/identify.js
+++ b/test/identify.js
@@ -1,7 +1,6 @@
 import test from 'ava'
 import { graphql } from 'graphql'
-import schemaBasic from '../test-api/schema-basic/index'
-import { partial } from 'lodash'
+import schema from '../test-api/schema-basic/index'
 import { errCheck } from './_util'
 
 function wrap(query) {
@@ -10,15 +9,14 @@ function wrap(query) {
   }`
 }
 
-const run = partial(graphql, schemaBasic)
 
 test('it should handle a where condition', async t => {
-  const query = `{
+  const source = `{
     user(id: 1) {
       fullName
     }
   }`
-  const { data, errors } = await run(query)
+  const { data, errors } = await graphql({schema, source})
   errCheck(t, errors)
   const expect = {
     user: { fullName: 'andrew carlson' }
@@ -27,12 +25,12 @@ test('it should handle a where condition', async t => {
 })
 
 test('it should handle an async where condition', async t => {
-  const query = `{
+  const source = `{
     user(idAsync: 1) {
       fullName
     }
   }`
-  const { data, errors } = await run(query)
+  const { data, errors } = await graphql({schema, source})
   errCheck(t, errors)
   const expect = {
     user: { fullName: 'andrew carlson' }
@@ -41,8 +39,8 @@ test('it should handle an async where condition', async t => {
 })
 
 test('a query with a sqlDeps as the first requested field should not mess it up', async t => {
-  const query = wrap('numFeet, fullName, id')
-  const { data, errors } = await run(query)
+  const source = wrap('numFeet, fullName, id')
+  const { data, errors } = await graphql({schema, source})
   errCheck(t, errors)
   const expect = {
     users: [
@@ -67,12 +65,12 @@ test('a query with a sqlDeps as the first requested field should not mess it up'
 })
 
 test('it should handle a single object in which the first requested field is a list', async t => {
-  const query = `{
+  const source = `{
     user(id: 2) {
       posts { id, body }
     }
   }`
-  const { data, errors } = await run(query)
+  const { data, errors } = await graphql({schema, source})
   errCheck(t, errors)
   const expect = {
     user: {
@@ -92,12 +90,12 @@ test('it should handle a single object in which the first requested field is a l
 })
 
 test('it should handle composite keys', async t => {
-  const query = `{
+  const source = `{
     sponsors {
       numLegs, lastName
     }
   }`
-  const { data, errors } = await run(query)
+  const { data, errors } = await graphql({schema, source})
   errCheck(t, errors)
   const expect = {
     sponsors: [

--- a/test/junctions.js
+++ b/test/junctions.js
@@ -1,13 +1,11 @@
 import test from 'ava'
 import { graphql } from 'graphql'
-import schemaBasic from '../test-api/schema-basic/index'
-import { partial } from 'lodash'
+import schema from '../test-api/schema-basic/index'
 import { errCheck } from './_util'
 
-const run = partial(graphql, schemaBasic)
 
 test('should handle data from the junction table', async t => {
-  const query = `{
+  const source = `{
     user(id: 3) {
       fullName
       following {
@@ -16,7 +14,7 @@ test('should handle data from the junction table', async t => {
       }
     }
   }`
-  const { data, errors } = await run(query)
+  const { data, errors } = await graphql({schema, source})
   errCheck(t, errors)
   const expect = {
     user: {

--- a/test/order.js
+++ b/test/order.js
@@ -1,7 +1,6 @@
 import test from 'ava'
 import { graphql } from 'graphql'
-import schemaBasic from '../test-api/schema-basic/index'
-import { partial } from 'lodash'
+import schema from '../test-api/schema-basic/index'
 import { errCheck } from './_util'
 
 function makeQuery(asc) {
@@ -20,11 +19,10 @@ function makeQuery(asc) {
   }`
 }
 
-const run = partial(graphql, schemaBasic)
 
 test('it should handle nested ordering with both ASC', async t => {
-  const query = makeQuery(true)
-  const { data, errors } = await run(query)
+  const source = makeQuery(true)
+  const { data, errors } = await graphql({schema, source})
   errCheck(t, errors)
   t.deepEqual(
     [{ id: 4 }, { id: 5 }, { id: 6 }, { id: 7 }, { id: 8 }],
@@ -34,8 +32,8 @@ test('it should handle nested ordering with both ASC', async t => {
 })
 
 test('it should handle nested ordering with one ASC and one DESC', async t => {
-  const query = makeQuery(false)
-  const { data, errors } = await run(query)
+  const source = makeQuery(false)
+  const { data, errors } = await graphql({schema, source})
   errCheck(t, errors)
   t.deepEqual(
     [{ id: 8 }, { id: 7 }, { id: 6 }, { id: 5 }, { id: 4 }],
@@ -45,7 +43,7 @@ test('it should handle nested ordering with one ASC and one DESC', async t => {
 })
 
 test('it should handle order on many-to-many', async t => {
-  const query = `{
+  const source = `{
     user(id: 3) {
       fullName
       following {
@@ -54,7 +52,7 @@ test('it should handle order on many-to-many', async t => {
       }
     }
   }`
-  const { data, errors } = await run(query)
+  const { data, errors } = await graphql({schema, source})
   errCheck(t, errors)
   const expect = {
     user: {
@@ -75,7 +73,7 @@ test('it should handle order on many-to-many', async t => {
 })
 
 test('it sould handle order on many-to-many', async t => {
-  const query = `{
+  const source = `{
     user(id: 3) {
       fullName
       following(oldestFirst: true) {
@@ -84,7 +82,7 @@ test('it sould handle order on many-to-many', async t => {
       }
     }
   }`
-  const { data, errors } = await run(query)
+  const { data, errors } = await graphql({schema, source})
   errCheck(t, errors)
   const expect = {
     user: {

--- a/test/pagination/keyset-paging.js
+++ b/test/pagination/keyset-paging.js
@@ -1,7 +1,7 @@
 import test from 'ava'
 import { graphql } from 'graphql'
-import schemaRelay from '../../test-api/schema-paginated/index'
-import { isEmpty, partial } from 'lodash'
+import schema from '../../test-api/schema-paginated/index'
+import { isEmpty } from 'lodash'
 import { toGlobalId, fromGlobalId } from 'graphql-relay'
 import { objToCursor } from '../../src/util'
 import { errCheck } from '../_util'
@@ -14,7 +14,6 @@ Object.defineProperty(Array.prototype, 'last', {
   enumberable: false
 })
 
-const run = partial(graphql, schemaRelay)
 
 function stringifyArgs(args) {
   if (!args) {
@@ -44,8 +43,8 @@ function makeUsersQuery(args) {
 }
 
 test('should handle pagination at the root', async t => {
-  const query = makeUsersQuery()
-  const { data, errors } = await run(query)
+  const source  = makeUsersQuery()
+  const { data, errors } = await graphql({schema, source})
   errCheck(t, errors)
   t.deepEqual(data.users.pageInfo, {
     hasNextPage: false,
@@ -63,8 +62,8 @@ test('should handle pagination at the root', async t => {
 })
 
 test('should handle root pagination with "first" arg', async t => {
-  const query = makeUsersQuery({ first: 2 })
-  const { data, errors } = await run(query)
+  const source  = makeUsersQuery({ first: 2 })
+  const { data, errors } = await graphql({schema, source})
   errCheck(t, errors)
   t.deepEqual(
     data.users.pageInfo,
@@ -96,11 +95,11 @@ test('should handle root pagination with "first" arg', async t => {
 })
 
 test('should reject an invalid cursor', async t => {
-  const query = makeUsersQuery({
+  const source  = makeUsersQuery({
     first: 2,
     after: objToCursor({ id: 2, created_at: '2016-01-01' })
   })
-  const { errors } = await run(query)
+  const { errors } = await graphql({schema, source})
   t.truthy(errors.length)
   t.regex(
     errors[0] && errors[0].message,
@@ -109,8 +108,8 @@ test('should reject an invalid cursor', async t => {
 })
 
 test('should handle root pagination with "first" and "after" args', async t => {
-  const query = makeUsersQuery({ first: 2, after: objToCursor({ id: 2 }) })
-  const { data, errors } = await run(query)
+  const source  = makeUsersQuery({ first: 2, after: objToCursor({ id: 2 }) })
+  const { data, errors } = await graphql({schema, source})
   errCheck(t, errors)
   t.deepEqual(
     data.users.pageInfo,
@@ -142,8 +141,8 @@ test('should handle root pagination with "first" and "after" args', async t => {
 })
 
 test('should handle the last page of root pagination', async t => {
-  const query = makeUsersQuery({ first: 2, after: objToCursor({ id: 5 }) })
-  const { data, errors } = await run(query)
+  const source  = makeUsersQuery({ first: 2, after: objToCursor({ id: 5 }) })
+  const { data, errors } = await graphql({schema, source})
   errCheck(t, errors)
   t.deepEqual(
     data.users.pageInfo,
@@ -176,8 +175,8 @@ test('should handle the last page of root pagination', async t => {
 })
 
 test('should return nothing after the end of root pagination', async t => {
-  const query = makeUsersQuery({ first: 3, after: objToCursor({ id: 6 }) })
-  const { data, errors } = await run(query)
+  const source  = makeUsersQuery({ first: 3, after: objToCursor({ id: 6 }) })
+  const { data, errors } = await graphql({schema, source})
   errCheck(t, errors)
   t.deepEqual(data.users, {
     pageInfo: {
@@ -191,8 +190,8 @@ test('should return nothing after the end of root pagination', async t => {
 })
 
 test('should handle backward pagination at root with "last" arg', async t => {
-  const query = makeUsersQuery({ last: 2 })
-  const { data, errors } = await run(query)
+  const source  = makeUsersQuery({ last: 2 })
+  const { data, errors } = await graphql({schema, source})
   errCheck(t, errors)
   t.deepEqual(data.users.pageInfo, {
     hasNextPage: false,
@@ -205,8 +204,8 @@ test('should handle backward pagination at root with "last" arg', async t => {
 })
 
 test('should handle backward pagination at root with "last" and "before" args', async t => {
-  const query = makeUsersQuery({ last: 1, before: objToCursor({ id: 2 }) })
-  const { data, errors } = await run(query)
+  const source  = makeUsersQuery({ last: 1, before: objToCursor({ id: 2 }) })
+  const { data, errors } = await graphql({schema, source})
   errCheck(t, errors)
   t.deepEqual(data.users.pageInfo, {
     hasNextPage: false,
@@ -233,8 +232,8 @@ function makePostsQuery(args) {
 }
 
 test('should handle pagination in a nested field', async t => {
-  const query = makePostsQuery()
-  const { data, errors } = await run(query)
+  const source  = makePostsQuery()
+  const { data, errors } = await graphql({schema, source})
   errCheck(t, errors)
   const posts = data.user.posts
   t.deepEqual(posts.pageInfo, {
@@ -263,8 +262,8 @@ test('should handle pagination in a nested field', async t => {
 })
 
 test('nested paging should handle "first" arg', async t => {
-  const query = makePostsQuery({ first: 3 })
-  const { data, errors } = await run(query)
+  const source  = makePostsQuery({ first: 3 })
+  const { data, errors } = await graphql({schema, source})
   errCheck(t, errors)
   const posts = data.user.posts
   t.deepEqual(posts.pageInfo, {
@@ -278,11 +277,11 @@ test('nested paging should handle "first" arg', async t => {
 })
 
 test('nested paging should handle "last" and "before" args', async t => {
-  const query = makePostsQuery({
+  const source  = makePostsQuery({
     last: 2,
     before: objToCursor({ created_at: '2016-04-13T15:07:15.119Z', id: 33 })
   })
-  const { data, errors } = await run(query)
+  const { data, errors } = await graphql({schema, source})
   errCheck(t, errors)
   const expect = {
     hasNextPage: false,
@@ -296,7 +295,7 @@ test('nested paging should handle "last" and "before" args', async t => {
 })
 
 test('can handle nested pagination', async t => {
-  const query = `{
+  const source  = `{
     users(first: 2) {
       edges {
         node {
@@ -310,7 +309,7 @@ test('can handle nested pagination', async t => {
       }
     }
   }`
-  const { data, errors } = await run(query)
+  const { data, errors } = await graphql({schema, source})
   errCheck(t, errors)
   t.is(data.users.edges.length, 2)
   t.is(data.users.edges[0].node.fullName, 'Alivia Waelchi')
@@ -326,7 +325,7 @@ test('can handle nested pagination', async t => {
 })
 
 test('can handle deeply nested pagination', async t => {
-  const query = `{
+  const source  = `{
     users(first: 1) {
       edges {
         node {
@@ -355,7 +354,7 @@ test('can handle deeply nested pagination', async t => {
       }
     }
   }`
-  const { data, errors } = await run(query)
+  const { data, errors } = await graphql({schema, source})
   errCheck(t, errors)
   const comments = data.users.edges[0].node.posts.edges[0].node.comments
   const expect = {
@@ -380,7 +379,7 @@ test('can handle deeply nested pagination', async t => {
 })
 
 test('handle a conection type with a many-to-many', async t => {
-  const query = `{
+  const source  = `{
     user(id: 2) {
       following(first: 2, after: "${objToCursor({
         created_at: '2016-01-01T16:28:00.051Z',
@@ -401,7 +400,7 @@ test('handle a conection type with a many-to-many', async t => {
       }
     }
   }`
-  const { data, errors } = await run(query)
+  const { data, errors } = await graphql({schema, source})
   errCheck(t, errors)
   t.deepEqual(data.user.following.pageInfo, {
     hasNextPage: true,
@@ -437,7 +436,7 @@ test('should handle pagination with duplicate objects', async t => {
   // notice the cyclical nature of this query. we get a user. then we get their posts.
   // then we get the author, who is that same user
   // we need to make sure join monster references the same object instead of cloning it
-  const query = `{
+  const source  = `{
     node(id: "${user1Id}") {
       ... on User {
         ...info
@@ -466,7 +465,7 @@ test('should handle pagination with duplicate objects', async t => {
       }
     }
   }`
-  const { data, errors } = await run(query)
+  const { data, errors } = await graphql({schema, source})
   errCheck(t, errors)
   const following = {
     edges: [{ node: { id: toGlobalId('User', 4) } }]
@@ -517,7 +516,7 @@ test('should handle pagination with duplicate objects', async t => {
 })
 
 test('should handle fragment usage with connections inside union or fragment ', async t => {
-  const query = `{
+  const source  = `{
     user(id: 1) {
       writtenMaterial {
         edges {
@@ -538,7 +537,7 @@ test('should handle fragment usage with connections inside union or fragment ', 
       }
     }
   }`
-  const { data, errors } = await run(query)
+  const { data, errors } = await graphql({schema, source})
   errCheck(t, errors)
   const firstPost = data.user.writtenMaterial.edges.filter(
     e => !isEmpty(e.node)
@@ -548,7 +547,7 @@ test('should handle fragment usage with connections inside union or fragment ', 
 })
 
 test('handle filtered pagination at the root', async t => {
-  const query = `{
+  const source  = `{
     users(search: "c%i") {
       edges {
         node {
@@ -557,7 +556,7 @@ test('handle filtered pagination at the root', async t => {
       }
     }
   }`
-  const { data, errors } = await run(query)
+  const { data, errors } = await graphql({schema, source})
   errCheck(t, errors)
   t.deepEqual(data, {
     users: {
@@ -574,7 +573,7 @@ test('handle filtered pagination at the root', async t => {
 })
 
 test('filtering on one-to-many-nested field', async t => {
-  const query = `{
+  const source  = `{
     user(id: 1) {
       posts(search: "ad") {
         edges {
@@ -585,7 +584,7 @@ test('filtering on one-to-many-nested field', async t => {
       }
     }
   }`
-  const { data, errors } = await run(query)
+  const { data, errors } = await graphql({schema, source})
   errCheck(t, errors)
   t.deepEqual(data.user.posts.edges, [
     {
@@ -609,7 +608,7 @@ test('filtering on one-to-many-nested field', async t => {
 })
 
 test('should handle emptiness', async t => {
-  const query = `{
+  const source  = `{
     user(id: 6) {
       following {
         edges {
@@ -634,7 +633,7 @@ test('should handle emptiness', async t => {
       }
     }
   }`
-  const { data, errors } = await run(query)
+  const { data, errors } = await graphql({schema, source})
   errCheck(t, errors)
   const expect = {
     user: {
@@ -650,7 +649,7 @@ test('should handle emptiness', async t => {
 })
 
 test('should handle a "where" condition on a paginated field', async t => {
-  const query = `{
+  const source  = `{
     users(first: 1) {
       edges {
         node {
@@ -671,7 +670,7 @@ test('should handle a "where" condition on a paginated field', async t => {
       }
     }
   }`
-  const { data, errors } = await run(query)
+  const { data, errors } = await graphql({schema, source})
   errCheck(t, errors)
   t.is(data.users.edges.length, 1)
   t.is(data.users.edges[0].node.fullName, 'Alivia Waelchi')
@@ -701,7 +700,7 @@ test('should handle a "where" condition on a paginated field', async t => {
 })
 
 test('should handle "where" condition on main table of many-to-many relation', async t => {
-  const query = `{
+  const source  = `{
     user(id: 3) {
       fullName
       following(intimacy: acquaintance) {
@@ -715,7 +714,7 @@ test('should handle "where" condition on main table of many-to-many relation', a
       }
     }
   }`
-  const { data, errors } = await run(query)
+  const { data, errors } = await graphql({schema, source})
   errCheck(t, errors)
   const expect = {
     user: {
@@ -737,7 +736,7 @@ test('should handle "where" condition on main table of many-to-many relation', a
 })
 
 test('should handle order columns on the main table', async t => {
-  const query = `{
+  const source  = `{
     user(id: 2) {
       fullName
       following(first: 2, sortOnMain: true, after: "${objToCursor({
@@ -753,7 +752,7 @@ test('should handle order columns on the main table', async t => {
       }
     }
   }`
-  const { data, errors } = await run(query)
+  const { data, errors } = await graphql({schema, source})
   errCheck(t, errors)
   const expect = {
     user: {
@@ -784,7 +783,7 @@ test('should handle order columns on the junction table', async t => {
     created_at: '2016-01-01T16:28:00.051Z',
     followee_id: 1
   })
-  const query = `{
+  const source  = `{
     user(id: 2) {
       fullName
       following(first: 2, sortOnMain: false, after: "${cursor}") {
@@ -797,7 +796,7 @@ test('should handle order columns on the junction table', async t => {
       }
     }
   }`
-  const { data, errors } = await run(query)
+  const { data, errors } = await graphql({schema, source})
   errCheck(t, errors)
   const expect = {
     user: {
@@ -824,7 +823,7 @@ test('should handle order columns on the junction table', async t => {
 })
 
 test('should handle an interface type', async t => {
-  const query = `{
+  const source  = `{
     user(id: 1) {
       writtenMaterial(first: 3) {
         pageInfo {
@@ -842,7 +841,7 @@ test('should handle an interface type', async t => {
       }
     }
   }`
-  const { data, errors } = await run(query)
+  const { data, errors } = await graphql({schema, source})
   errCheck(t, errors)
   const expect = {
     pageInfo: {
@@ -887,7 +886,7 @@ test('should handle an interface type', async t => {
 })
 
 test('should use default page limit if set', async t => {
-  const query = `{
+  const source  = `{
     users {
       edges{
         node{
@@ -903,13 +902,13 @@ test('should use default page limit if set', async t => {
       }
     }
   }`
-  const { data, errors } = await run(query)
+  const { data, errors } = await graphql({schema, source})
   errCheck(t, errors)
   t.deepEqual(data.users.edges[0].node.comments.edges.length, 2)
 })
 
 test('should allow explicit page limit larger than default page size', async t => {
-  const query = `{
+  const source  = `{
     users {
       edges{
         node{
@@ -925,7 +924,7 @@ test('should allow explicit page limit larger than default page size', async t =
       }
     }
   }`
-  const { data, errors } = await run(query)
+  const { data, errors } = await graphql({schema, source})
   errCheck(t, errors)
   t.deepEqual(data.users.edges[0].node.comments.edges.length, 3)
 })

--- a/test/pagination/limit.js
+++ b/test/pagination/limit.js
@@ -1,18 +1,16 @@
 import test from 'ava'
 import { graphql } from 'graphql'
-import schemaRelay from '../../test-api/schema-paginated/index'
-import { partial } from 'lodash'
+import schema from '../../test-api/schema-paginated/index'
 import { errCheck } from '../_util'
 
-const run = partial(graphql, schemaRelay)
 
 test('should handle limit at the root', async t => {
-  const query = `{
+  const source = `{
     usersFirst2 {
       fullName
     }
   }`
-  const { data, errors } = await run(query)
+  const { data, errors } = await graphql({schema, source})
   errCheck(t, errors)
   const expect = {
     usersFirst2: [{ fullName: 'andrew carlson' }, { fullName: 'matt elder' }]
@@ -21,14 +19,14 @@ test('should handle limit at the root', async t => {
 })
 
 test('should handle limit for one-to-many', async t => {
-  const query = `{
+  const source = `{
     user(id: 1) {
       commentsLast2 {
         id
       }
     }
   }`
-  const { data, errors } = await run(query)
+  const { data, errors } = await graphql({schema, source})
   errCheck(t, errors)
   const expect = {
     user: {
@@ -39,14 +37,14 @@ test('should handle limit for one-to-many', async t => {
 })
 
 test('should handle limit for many-to-many', async t => {
-  const query = `{
+  const source = `{
     user(id: 3) {
       followingFirst {
         fullName
       }
     }
   }`
-  const { data, errors } = await run(query)
+  const { data, errors } = await graphql({schema, source})
   errCheck(t, errors)
   const expect = {
     user: {

--- a/test/relations.js
+++ b/test/relations.js
@@ -1,7 +1,6 @@
 import test from 'ava'
 import { graphql } from 'graphql'
-import schemaBasic from '../test-api/schema-basic/index'
-import { partial } from 'lodash'
+import schema from '../test-api/schema-basic/index'
 import { errCheck } from './_util'
 
 function wrap(query, id) {
@@ -15,11 +14,10 @@ function wrap(query, id) {
   }`
 }
 
-const run = partial(graphql, schemaBasic)
 
 test('should join a one-to-many relation', async t => {
-  const query = wrap('id, comments { id, body }')
-  const { data, errors } = await run(query)
+  const source = wrap('id, comments { id, body }')
+  const { data, errors } = await graphql({schema, source})
   errCheck(t, errors)
   const expect = {
     users: [
@@ -81,14 +79,14 @@ test('should join a one-to-many relation', async t => {
 })
 
 test('should join on a nested relation', async t => {
-  const query = wrap(`
+  const source = wrap(`
     comments {
       id
       body
       author { fullName }
     }
   `)
-  const { data, errors } = await run(query)
+  const { data, errors } = await graphql({schema, source})
   errCheck(t, errors)
   const expect = {
     users: [
@@ -156,7 +154,7 @@ test('should join on a nested relation', async t => {
 })
 
 test('should handle where conditions on the relations', async t => {
-  const query = wrap(
+  const source = wrap(
     `
     posts(active: true) {
       id
@@ -177,7 +175,7 @@ test('should handle where conditions on the relations', async t => {
   `,
     2
   )
-  const { data, errors } = await run(query)
+  const { data, errors } = await graphql({schema, source})
   errCheck(t, errors)
   const expect = {
     user: {
@@ -208,7 +206,7 @@ test('should handle where conditions on the relations', async t => {
 })
 
 test('should handle where condition on many-to-many relation', async t => {
-  const query = wrap(
+  const source = wrap(
     `
     id
     fullName
@@ -218,7 +216,7 @@ test('should handle where condition on many-to-many relation', async t => {
   `,
     3
   )
-  const { data, errors } = await run(query)
+  const { data, errors } = await graphql({schema, source})
   errCheck(t, errors)
   const expect = {
     user: {
@@ -231,7 +229,7 @@ test('should handle where condition on many-to-many relation', async t => {
 })
 
 test('should include data from the junction table', async t => {
-  const query = wrap(
+  const source = wrap(
     `
     id
     fullName
@@ -245,7 +243,7 @@ test('should include data from the junction table', async t => {
   `,
     3
   )
-  const { data, errors } = await run(query)
+  const { data, errors } = await graphql({schema, source})
   errCheck(t, errors)
   const expect = {
     user: {
@@ -273,7 +271,7 @@ test('should include data from the junction table', async t => {
 })
 
 test('should handle where condition on junction in many-to-many', async t => {
-  const query = wrap(
+  const source = wrap(
     `
     id
     fullName
@@ -284,7 +282,7 @@ test('should handle where condition on junction in many-to-many', async t => {
   `,
     3
   )
-  const { data, errors } = await run(query)
+  const { data, errors } = await graphql({schema, source})
   errCheck(t, errors)
   const expect = {
     user: {
@@ -302,7 +300,7 @@ test('should handle where condition on junction in many-to-many', async t => {
 })
 
 test('should handle joins with the same table name', async t => {
-  const query = wrap(`
+  const source = wrap(`
     idEncoded
     globalId
     email
@@ -318,7 +316,7 @@ test('should handle joins with the same table name', async t => {
       }
     }
   `)
-  const { data, errors } = await run(query)
+  const { data, errors } = await graphql({schema, source})
   errCheck(t, errors)
   const expect = {
     users: [
@@ -483,12 +481,12 @@ test('should handle joins with the same table name', async t => {
 })
 
 test('it should handle many to many relationship', async t => {
-  const query = wrap(`
+  const source = wrap(`
     id
     fullName
     following { fullName }
   `)
-  const { data, errors } = await run(query)
+  const { data, errors } = await graphql({schema, source})
   errCheck(t, errors)
   const expect = {
     users: [
@@ -524,7 +522,7 @@ test('it should handle many to many relationship', async t => {
 })
 
 test('it should handle fragments nested lower', async t => {
-  const query = `
+  const source = `
     {
       users {
         ...F0
@@ -540,7 +538,7 @@ test('it should handle fragments nested lower', async t => {
     fragment F2 on Comment { id }
     fragment F3 on Comment { body }
   `
-  const { data, errors } = await run(query)
+  const { data, errors } = await graphql({schema, source})
   errCheck(t, errors)
   const expect = {
     users: [
@@ -633,7 +631,7 @@ test('it should handle fragments nested lower', async t => {
 })
 
 test('should handle a correlated subquery', async t => {
-  const query = wrap(
+  const source = wrap(
     `
     posts(active: false) {
       id
@@ -644,7 +642,7 @@ test('should handle a correlated subquery', async t => {
   `,
     2
   )
-  const { data, errors } = await run(query)
+  const { data, errors } = await graphql({schema, source})
   errCheck(t, errors)
   const expect = {
     user: {

--- a/test/scalars-as-tables.js
+++ b/test/scalars-as-tables.js
@@ -1,21 +1,19 @@
 import test from 'ava'
 import { graphql } from 'graphql'
-import schemaRelay from '../test-api/schema-paginated/index'
-import { partial } from 'lodash'
+import schema from '../test-api/schema-paginated/index'
 import { errCheck } from './_util'
 
-const run = partial(graphql, schemaRelay)
 
 test('it should get a scalar list and resolve it', async t => {
-  const { data, errors } = await run(`
+  const source = `
     query {
       post(id: 1) {
         id
         tags
       }
     }
-  `)
-
+  `
+  const { data, errors } = await graphql({schema, source})
   errCheck(t, errors)
   t.deepEqual(['foo', 'bar', 'baz'], data.post.tags)
 })

--- a/test/union.js
+++ b/test/union.js
@@ -1,13 +1,11 @@
 import test from 'ava'
 import { graphql } from 'graphql'
-import schemaBasic from '../test-api/schema-basic/index'
-import { partial } from 'lodash'
+import schema from '../test-api/schema-basic/index'
 import { errCheck } from './_util'
 
-const run = partial(graphql, schemaBasic)
 
 test('it should a union type', async t => {
-  const query = `
+  const source = `
     {
       user(id: 1) {
         writtenMaterial1 {
@@ -32,7 +30,7 @@ test('it should a union type', async t => {
       authorId
     }
   `
-  const { data, errors } = await run(query)
+  const { data, errors } = await graphql({schema, source})
   errCheck(t, errors)
   const expect = {
     user: {
@@ -83,7 +81,7 @@ test('it should a union type', async t => {
 })
 
 test('it should an interface type', async t => {
-  const query = `
+  const source = `
     {
       user(id: 1) {
         writtenMaterial2 {
@@ -101,7 +99,7 @@ test('it should an interface type', async t => {
       }
     }
   `
-  const { data, errors } = await run(query)
+  const { data, errors } = await graphql({schema, source})
   errCheck(t, errors)
   const expect = {
     user: {


### PR DESCRIPTION

### Description

The purpose of this PR is to upgrade join-monster to support graphql@16_6_0. There were a number of breaking changes introduced in graphql version 16 that had a major impact (mostly) to the tests and to some of the code in join-monster. This PR fixes these changes so the tests pass. I can't guarantee that other breaking changes were not caught by the tests.
Some of the breaking fixes of graphql v16:

1. https://github.com/graphql/graphql-js/pull/2904. This was, by far, the largest change as it broke most tests due to their reliance on `lodash partial`. I just removed that dependency and fixed the parameters so that they would align with the v16 approach. So for example:
 ```
import { partial } from 'lodash'
     const run = partial(graphql, schemaBasic)
     const { data, errors } = await run(query) <--- old approach
```
was changed to:
```
      const { data, errors } = await graphql({schema, source}) <--- new approach
 ```

2. Fragment tests failed due to a change in structure. I couldn't find the PR in graphql that impacted this one but the changes were mostly the main join-master index.js. Without these changes a number of the relay tests failed with the following error: `def.args is not iterable` and some code in graphql was added to iterate through this structure which in most cases  was an array (only the failed cases were not an array). So I changed this definition to be an array (see `src/index.js` change.

3. Other fragment tests failed with `Support for returning GraphQLObjectType from resolveType was removed in graphql-js@16.0.0 please return type name instead` and this was fixed also in `src/index.js` to add `name` to `type`.

4. An error occurred: `TypeError: Class constructor GraphQLNonNull cannot be invoked without 'new'` that was fixed as well.

### Testing

To test this change it is necessary (still) to use node v14 (`nvm use 14`).

It is important to ensure that `graphql@16_6_0` is installed.

I ran the following suites:
- `npm run testsqlite3`
- `npm run testpg` 
- `npm run testpg-paging` (postgres)
- `npm run testmysql` and 
- `npm run testmysql-paging` (mysql)

all passed, except for the offset cursor tests in mysql which were throwing an error `This type of pagination not supported on this dialect` which is a join-monster error and I believe expected.


- [x] This change adds test coverage for new/changed/fixed functionality (note: I did not add any new tests as the code and tests were just updated to support the breaking changes of graphql v16)

### Checklist

- [x] I have added documentation for new/changed functionality in this PR via comments and by updating the change log
