### PR TITLE
 fix for tag install issue

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### vNEXT (June 23, 2023)
 
+### v3.3.1 (June 16, 2023)
+- [#502](https://github.com/join-monster/join-monster/pull/502): npm installer did not like the support specified as  "graphql@^16.0.0|^15.4.0" in the package.json. This PR backs this out and only specifies support for 16.X.
 ### v3.3.0 (June 26, 2023)
 #### Updated
 - [#495](https://github.com/join-monster/join-monster/pull/495): Added support for GraphQL v16_6_0. There were a number of breaking changes introduced in GraphQL v16 and these impacted a large number of tests and bit of the code. This provides fixes for those breaking changes. It also drops support for Node versions 10 - 13 but adds support for Node v16.

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "graphql": "^16.0.0|^15.4.0"
+        "graphql": "^16.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
   },
   "homepage": "https://github.com/join-monster/join-monster#readme",
   "peerDependencies": {
-    "graphql": "^16.0.0|^15.4.0"
+    "graphql": "^16.0.0"
   },
   "devDependencies": {
     "@ava/babel-preset-stage-4": "^1.1.0",


### PR DESCRIPTION

### Description

the npm install command did not like the package.json syntax for supporting 15 and 16 versions of graphql. this didn't show up in all of the tests until I did a manual install of the pushed join-monster v 3.3.0. this patches the problem by only supporting version 16.

The error looks as follows:
```
c889f3bd2e05 test-proj % npm install join-monster      
npm ERR! code EINVALIDTAGNAME
npm ERR! Invalid tag name "^16.0.0|^15.4.0" of package "graphql@^16.0.0|^15.4.0": Tags may not have any characters that encodeURIComponent encodes.

```



- [x ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x ] I have added documentation for new/changed functionality in this PR via comments and by updating the change log
