### PR TITLE
 eliminate dynamic require so join-monster can be used with react native

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### vNEXT (June 23, 2023)
+- [#506](https://github.com/join-monster/join-monster/pull/506): Removed use of dynamic require which was preventing use of join-monster with react native deployments.
 
 ### v3.3.1 (June 16, 2023)
 - [#502](https://github.com/join-monster/join-monster/pull/502): npm installer did not like the support specified as  "graphql@^16.0.0|^15.4.0" in the package.json. This PR backs this out and only specifies support for 16.X of graphql in the peer dependencies

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,5 @@
 ### vNEXT (June 23, 2023)
-- [#506](https://github.com/join-monster/join-monster/pull/506): Removed use of dynamic require which was preventing use of join-monster with react native deployments.
+- [#506](https://github.com/join-monster/join-monster/pull/506): Removed use of dynamic require which was preventing join-monster  deployments with react native.
 
 ### v3.3.1 (June 16, 2023)
 - [#502](https://github.com/join-monster/join-monster/pull/502): npm installer did not like the support specified as  "graphql@^16.0.0|^15.4.0" in the package.json. This PR backs this out and only specifies support for 16.X of graphql in the peer dependencies

--- a/src/stringifiers/dispatcher.js
+++ b/src/stringifiers/dispatcher.js
@@ -16,7 +16,16 @@ export default async function stringifySqlAST(topNode, context, options) {
   let dialect = options.dialectModule
 
   if (!dialect && options.dialect) {
-    dialect = require('./dialects/' + options.dialect)
+    // dialect = require('./dialects/' + options.dialect)
+    const dialectRequireOptions = {
+      sqlite3: require('./dialects/sqlite3'),
+      pg: require('./dialects/pg'),
+      oracle: require('./dialects/oracle'),
+      mysql8: require('./dialects/mysql8'),
+      mysql: require('./dialects/mysql'),
+      mariadb: require('./dialects/mariadb'),
+    }
+    dialect = dialectRequireOptions[options.dialect]
   }
 
   // recursively figure out all the selections, joins, and where conditions that we need

--- a/src/stringifiers/dispatcher.js
+++ b/src/stringifiers/dispatcher.js
@@ -16,7 +16,6 @@ export default async function stringifySqlAST(topNode, context, options) {
   let dialect = options.dialectModule
 
   if (!dialect && options.dialect) {
-    // dialect = require('./dialects/' + options.dialect)
     const dialectRequireOptions = {
       sqlite3: require('./dialects/sqlite3'),
       pg: require('./dialects/pg'),


### PR DESCRIPTION

### Description

This PR eliminates a dynamic require within join-monster that prevents it use within a react-native application.
When trying to use it with react-native the following error occurs:
```
Dynamic require defined at line 16; not supported by Metro
```
see issue [#join-monster-issue-505 ](https://github.com/join-monster/join-monster/issues/505).

The offending piece of code is in `src/stringifiers/dispatcher.js`:
```
if (!dialect && options.dialect) {
    dialect = require('./dialects/' + options.dialect)
}
```

This PR fixes this.

### References



### Testing

1. ran the tests with pg, sqlite3, pg-paging, and mysql
2. also verified that this worked for react native.

- [ x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x ] I have added documentation for new/changed functionality in this PR via comments and by updating the change log
