### PR TITLE
Handle disjoint fields requested across union types

### DIFF
--- a/src/resolve-unions.js
+++ b/src/resolve-unions.js
@@ -61,11 +61,68 @@ export default function resolveUnions(data, sqlAST) {
   }
 }
 
+/**
+ * Uses the resolveType() function to choose which data is selected for a given field.
+ *
+ * A query that selects different fields from a union type can result in having data from more than one member of the
+ * union.
+ *
+ * For example:
+ *   type Post { author: User }
+ *   type Comment { author: user }
+ *
+ *   union WrittenMaterial = Post | Comment
+ *
+ *   query {
+ *       writtenMaterial {
+ *           ... on Comment {
+ *             author {
+ *               capitalizedLastName # <-- First "disjoint" field selection from author type
+ *             }
+ *           }
+ *           ... on Post {
+ *             author {
+ *               email # <-- Second "disjoint" field selection from author type
+ *             }
+ *           }
+ *       }
+ *   }
+ *
+ *   The data returned from this query, when a Post and a Comment have the same author, can look like this FOR ANY GIVEN
+ *   comment OR post:
+ *   data: {
+ *    "author@Comment": {"id": 1, "capitalizedLastName": "CARLSON"},
+ *    "author@Post": {"id": 1, "email": "andrew@stem.is"}
+ *   }
+ *
+ *   Where any particular result is a Comment, we need to pick the Comment-shaped data, and not the Post-shaped data, and vice-versa.
+ *
+ *   This function calls resolveType() on the schema for the given data in order to pick which key to use for the requested field.
+ *
+ *   Where it is not possible to use resolveType() to choose, the first-encountered key will be used as the field.
+ *
+ *   The resolveType function must be a function that takes 0 or 1 arguments and returns a string. It cannot accept the
+ *   context or info objects, or return a Promise.
+ *
+ * @param obj
+ * @param childASTsql
+ * @param typeName
+ * @param qualifiedName
+ * @param requestedFieldName
+ */
 const disambiguateQualifiedTypeFields = (obj, childASTsql, typeName, qualifiedName, requestedFieldName) => {
-  const discriminatorTypeName = childASTsql.defferedFrom.resolveType ? childASTsql.defferedFrom.resolveType(obj) : null
   const qualifiedValue = obj[qualifiedName]
   delete obj[qualifiedName]
-  if (typeName !== discriminatorTypeName) {
+
+  const resolveType = childASTsql.defferedFrom?.resolveType
+  const resolveTypeFn = typeof resolveType === 'function' && resolveType.length < 2 ? resolveType : null
+  const resolveTypeResult = resolveTypeFn ? resolveTypeFn(obj) : null
+  const discriminatorTypeName = typeof resolveTypeResult === 'string' ? resolveTypeResult : null
+
+  const fieldTypeMatchesResolvedType = discriminatorTypeName && typeName === discriminatorTypeName
+
+  if (!fieldTypeMatchesResolvedType) {
+    // Remove the field@TypeName from obj without replacing it
     return
   }
 

--- a/test/union.js
+++ b/test/union.js
@@ -148,3 +148,73 @@ test('it should an interface type', async t => {
   }
   t.deepEqual(expect, data)
 })
+
+test('it should return disjoint fields requests for union type', async t => {
+  const source = `
+    {
+      user(id: 1) {
+        writtenMaterial1 {
+          __typename
+          
+          ... on Comment {
+            id
+            author {
+              capitalizedLastName # <-- First "disjoint" field selection from author type
+            }
+          }
+          ... on Post {
+            id
+            author {
+              email # <-- Second "disjoint" field selection from author type
+            }
+          }
+        }
+      }
+    }
+  `
+  const { data, errors } = await graphql({schema, source})
+  errCheck(t, errors)
+  const expect = {
+    user: {
+      writtenMaterial1: [
+        {
+          __typename: 'Comment',
+          id: 1,
+          author : {
+            capitalizedLastName: 'CARLSON',
+          }
+        },
+        {
+          __typename: 'Post',
+          id: 2,
+          author : {
+            email: 'andrew@stem.is'
+          }
+
+        },
+        {
+          __typename: 'Comment',
+          id: 4,
+          author : {
+            capitalizedLastName: 'CARLSON'
+          }
+        },
+        {
+          __typename: 'Comment',
+          id: 6,
+          author : {
+            capitalizedLastName: 'CARLSON'
+          }
+        },
+        {
+          __typename: 'Comment',
+          id: 8,
+          author : {
+            capitalizedLastName: 'CARLSON'
+          }
+        }
+      ]
+    }
+  }
+  t.deepEqual(expect, data)
+})


### PR DESCRIPTION


### Description

An incomplete fix for the issue described at:
https://github.com/join-monster/join-monster/issues/512

It is incomplete because this solution does not handle sqlBatch. Resulting in the same non-deterministic behaviour as non-batching. I ran out of steam attempting to address the `sqlBatch` case, and wasn't sure how to proceed. Suggestions welcome!

### References

> Include any links supporting this change such as a:

GitHub Issue/PR number addressed or fixed: https://github.com/join-monster/join-monster/issues/512


### Testing

> Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.
>
> Also include details of the environment this PR was developed in (language/platform/browser version).

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR via comments and by updating the change log
  - inline source comments added. No further documentation added.
  - no Changelog added (yet) until the `sqlBatch` issue is resolved and the test suite passes
