### PR TITLE
fix minify jm issues

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 ### vNEXT 
 
+### v3.3.3 (March 25, 2024)
+#### Fixed
+- [#514](https://github.com/join-monster/join-monster/pull/514): Fix of minify issues that cause production builds of react native to fail.
+
 ### v3.3.2 (August 27, 2023)
 #### Fixed
 - [#506](https://github.com/join-monster/join-monster/pull/506): Removed use of dynamic require which was preventing join-monster deployments with react native. Tested with expo-sqlite on Android (outside of this environment). 


### PR DESCRIPTION

### Description

React native deployments include a process to minify the code. This causes join monster to fail: https://github.com/join-monster/join-monster/issues/250. There are work arounds as described in that issue. This PR fixes the issue so that the work arounds are no longer needed.

To fix the problem we replace the calls to the `constructor.name` with calls that leverage some utility functions provided by graphql that provide equivalent behavior but are minify safe. So for example the following 
```
if (gqlType.constructor.name === 'GraphQLList') {
```
can be replace with:
```
if (isListType(gqlType) {
```
We create a utility function that handles a list of the checked types (as this is done in the code). 


### References



### Testing

This has been tested with regression tests and in a separate repository I tested it with expo. The default `expo start` does not invoke minify, but `expo start --no-dev --minify` does. I reproduced it first, and then tested that the code works correctly using minify.

- [x ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x ] I have added documentation for new/changed functionality in this PR via comments and by updating the change log
