### PR TITLE
[CI]: second attempt to fixing docker flakiness when starting services

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
-MYSQL_PORT=43306
-POSTGRES_PORT=45432
+MYSQL_PORT=3306
+POSTGRES_PORT=5432
 
 # for postgres this will be the superuser
 DB_USER=user

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -54,18 +54,26 @@ jobs:
       - name: Install Node Deps
         run: npm ci
 
+      - name: Run lsof
+        run: sudo lsof -i -n
+
       - name: Startup Databases
         run: |
           npm run db-up
           echo 'Waiting for DBs to start'
           npm run db-wait
 
+      - name: Early exit
+        run: |
+          gh run cancel ${{ github.run_id }}
+          gh run watch ${{ github.run_id }}
+      
       - name: Build Test Databases
         run: npm run db-build
 
       - name: Run Tests
         run: npm test
-
+        
       - uses: actions/upload-artifact@v3
         if: failure()
         with:

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -54,19 +54,11 @@ jobs:
       - name: Install Node Deps
         run: npm ci
 
-      - name: Run lsof
-        run: sudo lsof -i -n
-
       - name: Startup Databases
         run: |
           npm run db-up
           echo 'Waiting for DBs to start'
           npm run db-wait
-
-      - name: Early exit
-        run: |
-          gh run cancel ${{ github.run_id }}
-          gh run watch ${{ github.run_id }}
       
       - name: Build Test Databases
         run: npm run db-build

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.3'
 services:
  mysql:
-  image: mysql@sha256:4552fcc5d3cdb8cdee76ee25cce28bf60b0eb3ce93d25ba3bfff7a66bfdcdee8
+  image: mysql:8.3
   command: --default-authentication-plugin=mysql_native_password
   restart: always
   volumes:
@@ -20,7 +20,7 @@ services:
     retries: 10
 
  postgres:
-  image: postgres@sha256:6b841c8f6a819884207402f1209a8116844365df15fca8cf556fc54a24c70800
+  image: postgres:16-bookworm
   restart: always
   volumes:
     - ./docker-entrypoint-initdb.d/postgres:/docker-entrypoint-initdb.d
@@ -33,7 +33,7 @@ services:
    - ../.env
 
  adminer:
-  image: adminer@sha256:b75eae89431e8469613b844e76382a26efc8601c17f446bcd81665bc87ca9a1f
+  image: adminer:4.8.1
   restart: always
   ports:
    - 48080:8080

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -7,7 +7,7 @@ services:
   volumes:
     - ./docker-entrypoint-initdb.d/mysql:/docker-entrypoint-initdb.d
   ports:
-   - ${MYSQL_PORT:-43306}:3306
+   - ${MYSQL_PORT:-3306}:3306
   environment:
    - MYSQL_USER=${DB_USER:-user}
    - MYSQL_PASSWORD=${DB_PASSWORD:-password}
@@ -25,7 +25,7 @@ services:
   volumes:
     - ./docker-entrypoint-initdb.d/postgres:/docker-entrypoint-initdb.d
   ports:
-   - ${POSTGRES_PORT:-45432}:5432
+   - ${POSTGRES_PORT:-5432}:5432
   environment:
     - POSTGRES_USER=${DB_USER:-user}
     - POSTGRES_PASSWORD=${DB_PASSWORD:-password}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -36,4 +36,4 @@ services:
   image: adminer:4.8.1
   restart: always
   ports:
-   - 48080:8080
+   - 8080:8080

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
     "postversion": "git push && git push --tags",
     "db-build": "TZ=UTC babel-node test-api/data/build.js",
     "db-shell": "sqlite3 --column --header test-api/data/db/demo-data.sl3",
-    "db-up": "docker-compose -f ./docker/docker-compose.yml up -d",
-    "db-down": "docker-compose -f ./docker/docker-compose.yml down --remove-orphans -v",
+    "db-up": "docker compose -f ./docker/docker-compose.yml up -d",
+    "db-down": "docker compose -f ./docker/docker-compose.yml down --remove-orphans -v",
     "db-wait": "while ! echo exit | docker inspect --format \"{{json .State.Health.Status }}\" docker_mysql_1 | grep 'healthy'; do sleep 1; done"
   },
   "ava": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "postversion": "git push && git push --tags",
     "db-build": "TZ=UTC babel-node test-api/data/build.js",
     "db-shell": "sqlite3 --column --header test-api/data/db/demo-data.sl3",
-    "db-up": "docker compose -f ./docker/docker-compose.yml up -d",
+    "db-up": "npm run db-down && docker compose -f ./docker/docker-compose.yml up -d",
     "db-down": "docker compose -f ./docker/docker-compose.yml down --remove-orphans -v",
     "db-wait": "while ! echo exit | docker inspect --format \"{{ .State.Health.Status }}\" docker-mysql-1 | grep 'healthy'; do sleep 1; done"
   },

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "db-shell": "sqlite3 --column --header test-api/data/db/demo-data.sl3",
     "db-up": "docker compose -f ./docker/docker-compose.yml up -d",
     "db-down": "docker compose -f ./docker/docker-compose.yml down --remove-orphans -v",
-    "db-wait": "while ! echo exit | docker inspect --format \"{{json .State.Health.Status }}\" docker_mysql_1 | grep 'healthy'; do sleep 1; done"
+    "db-wait": "while ! echo exit | docker inspect --format \"{{ .State.Health.Status }}\" docker-mysql-1 | grep 'healthy'; do sleep 1; done"
   },
   "ava": {
     "verbose": true,


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Code of Conduct](https://github.com/join-monster/join-monster/blob/master/CODE_OF_CONDUCT.md). Please see the [contributing guidelines](https://github.com/join-monster/join-monster/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Update from docker-compose to docker compose
Use tagged versions of images
Main problem was port numbers

before:
43306 for mysql
45432 for pg
48080 for adminer

after
3306 for mysql
5432 for pg
8080 for adminer

With that change I ran GHA 20 times and there were no more address in use errors.

### References

> Include any links supporting this change such as a:
>
> - fixes #515 

### Testing

> Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.
>
> Also include details of the environment this PR was developed in (language/platform/browser version).

- [X] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [X] I have added documentation for new/changed functionality in this PR via comments and by updating the change log
