### PR TITLE
Add `aliasPrefix` option

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -57,6 +57,8 @@ if [ $PG = 1 ]; then
   npm run testpg-paging
   MINIFY=1 npm run testpg
   MINIFY=1 npm run testpg-paging
+  MINIFY=1 ALIAS_PREFIX="$" npm run testpg
+  MINIFY=1 ALIAS_PREFIX="$" npm run testpg-paging
 fi
 
 echo -e "${BLUE} running with all batches ${NC}"
@@ -80,6 +82,8 @@ if [ $PG = 1 ]; then
   STRATEGY=batch npm run testpg-paging
   STRATEGY=batch MINIFY=1 npm run testpg
   STRATEGY=batch MINIFY=1 npm run testpg-paging
+  STRATEGY=batch MINIFY=1 ALIAS_PREFIX="$" npm run testpg
+  STRATEGY=batch MINIFY=1 ALIAS_PREFIX="$" npm run testpg-paging
 fi
 
 echo -e "${BLUE} running with mixture ${NC}"
@@ -102,6 +106,8 @@ if [ $PG = 1 ]; then
   STRATEGY=mix npm run testpg-paging
   STRATEGY=mix MINIFY=1 npm run testpg
   STRATEGY=mix MINIFY=1 npm run testpg-paging
+  STRATEGY=mix MINIFY=1 ALIAS_PREFIX="$" npm run testpg
+  STRATEGY=mix MINIFY=1 ALIAS_PREFIX="$" npm run testpg-paging
 fi
 
 echo -e "${YELLOW} testing typescript definitions${NC}"

--- a/docs/API.md
+++ b/docs/API.md
@@ -43,6 +43,7 @@ Takes the GraphQL resolveInfo and returns a hydrated Object with the data.
 | dbCall | [<code>dbCall</code>](#dbCall) | A function that is passed the compiled SQL that calls the database and returns a promise of the data. |
 | [options] | <code>Object</code> |  |
 | options.minify | <code>Boolean</code> | Generate minimum-length column names in the results table. |
+| options.prefixAliases | <code>Boolean</code> | Prefix column and table names with "$" to avoid conflicts in subquery expressions. |
 | options.dialect | <code>String</code> | The dialect of SQL your Database uses. Currently `'pg'`, `'oracle'`, `'mariadb'`, `'mysql'`, and `'sqlite3'` are supported. |
 | options.dialectModule | <code>Object</code> | An alternative to options.dialect. You can provide a custom implementation of one of the supported dialects. |
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -43,7 +43,7 @@ Takes the GraphQL resolveInfo and returns a hydrated Object with the data.
 | dbCall | [<code>dbCall</code>](#dbCall) | A function that is passed the compiled SQL that calls the database and returns a promise of the data. |
 | [options] | <code>Object</code> |  |
 | options.minify | <code>Boolean</code> | Generate minimum-length column names in the results table. |
-| options.prefixAliases | <code>Boolean</code> | Prefix column and table names with "$" to avoid conflicts in subquery expressions. |
+| options.aliasPrefix | <code>String</code> | String to prefix to column and table names, useful to avoid conflicts in subquery expressions. |
 | options.dialect | <code>String</code> | The dialect of SQL your Database uses. Currently `'pg'`, `'oracle'`, `'mariadb'`, `'mysql'`, and `'sqlite3'` are supported. |
 | options.dialectModule | <code>Object</code> | An alternative to options.dialect. You can provide a custom implementation of one of the supported dialects. |
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [#523](https://github.com/join-monster/join-monster/pull/523): Make demo runnable again.
 - [#522](https://github.com/join-monster/join-monster/pull/522): Version bumps for critical dependencies.
 - [#519](https://github.com/join-monster/join-monster/pull/519): Handle disjoint fields requested across union types
+- [#532](https://github.com/join-monster/join-monster/pull/533): Add `prefixAliases` option.
 
 ### v3.3.4 (March 28, 2024)
 #### Fixed

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,7 +6,7 @@
 - [#523](https://github.com/join-monster/join-monster/pull/523): Make demo runnable again.
 - [#522](https://github.com/join-monster/join-monster/pull/522): Version bumps for critical dependencies.
 - [#519](https://github.com/join-monster/join-monster/pull/519): Handle disjoint fields requested across union types
-- [#532](https://github.com/join-monster/join-monster/pull/533): Add `prefixAliases` option.
+- [#532](https://github.com/join-monster/join-monster/pull/533): Add `aliasPrefix` option.
 
 ### v3.3.4 (March 28, 2024)
 #### Fixed

--- a/src/alias-namespace.js
+++ b/src/alias-namespace.js
@@ -3,8 +3,9 @@ import G from 'generatorics'
 // this class is responsible for generating the aliases that appear in each SQL query
 // this has different rules depending on whether we are aliasing a column or table and on whether we are minifying
 export default class AliasNamespace {
-  constructor(minify) {
+  constructor(minify, prefixAliases) {
     this.minify = !!minify
+    this.aliasPrefix = prefixAliases ? '$' : ''
 
     // a generator for infinite alias names, starting with the shortest possible
     // this is helpful for generating the names when minifying
@@ -25,7 +26,7 @@ export default class AliasNamespace {
     if (this.minify) {
       // tables definitely all need unique names
       if (type === 'table') {
-        return this.mininym.next().value.join('')
+        return `${this.aliasPrefix}${this.mininym.next().value.join('')}`
       }
 
       // but if its a column, we dont need to worry about the uniqueness from other columns

--- a/src/alias-namespace.js
+++ b/src/alias-namespace.js
@@ -26,7 +26,7 @@ export default class AliasNamespace {
     if (this.minify) {
       // tables definitely all need unique names
       if (type === 'table') {
-        return `${this.aliasPrefix}${this.mininym.next().value.join('')}`
+        return `${this.prefixAliases}${this.mininym.next().value.join('')}`
       }
 
       // but if its a column, we dont need to worry about the uniqueness from other columns

--- a/src/alias-namespace.js
+++ b/src/alias-namespace.js
@@ -43,7 +43,7 @@ export default class AliasNamespace {
       return name
     }
 
-    name = name
+    name = this.aliasPrefix + name
       .replace(/\s+/g, '')
       .replace(/[^a-zA-Z0-9]/g, '_')
       .slice(0, 10)

--- a/src/alias-namespace.js
+++ b/src/alias-namespace.js
@@ -5,7 +5,7 @@ import G from 'generatorics'
 export default class AliasNamespace {
   constructor(minify, prefixAliases) {
     this.minify = !!minify
-    this.aliasPrefix = prefixAliases ? '$' : ''
+    this.prefixAliases = prefixAliases ?? ''
 
     // a generator for infinite alias names, starting with the shortest possible
     // this is helpful for generating the names when minifying

--- a/src/alias-namespace.js
+++ b/src/alias-namespace.js
@@ -3,9 +3,9 @@ import G from 'generatorics'
 // this class is responsible for generating the aliases that appear in each SQL query
 // this has different rules depending on whether we are aliasing a column or table and on whether we are minifying
 export default class AliasNamespace {
-  constructor(minify, prefixAliases) {
+  constructor(minify, aliasPrefix) {
     this.minify = !!minify
-    this.prefixAliases = prefixAliases ?? ''
+    this.aliasPrefix = aliasPrefix ?? ''
 
     // a generator for infinite alias names, starting with the shortest possible
     // this is helpful for generating the names when minifying
@@ -26,7 +26,7 @@ export default class AliasNamespace {
     if (this.minify) {
       // tables definitely all need unique names
       if (type === 'table') {
-        return `${this.prefixAliases}${this.mininym.next().value.join('')}`
+        return `${this.aliasPrefix}${this.mininym.next().value.join('')}`
       }
 
       // but if its a column, we dont need to worry about the uniqueness from other columns

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -141,6 +141,7 @@ interface DialectModule {
 type Dialect = 'pg' | 'oracle' | 'mariadb' | 'mysql' | 'mysql8' | 'sqlite3'
 type JoinMonsterOptions = {
   minify?: boolean
+  prefixAliases?: boolean;
   dialect?: Dialect
   dialectModule?: DialectModule
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -141,7 +141,7 @@ interface DialectModule {
 type Dialect = 'pg' | 'oracle' | 'mariadb' | 'mysql' | 'mysql8' | 'sqlite3'
 type JoinMonsterOptions = {
   minify?: boolean
-  prefixAliases?: boolean;
+  aliasPrefix?: string;
   dialect?: Dialect
   dialectModule?: DialectModule
 }

--- a/src/index.js
+++ b/src/index.js
@@ -81,7 +81,7 @@ import {
  * @param {dbCall} dbCall - A function that is passed the compiled SQL that calls the database and returns a promise of the data.
  * @param {Object} [options]
  * @param {Boolean} options.minify - Generate minimum-length column names in the results table.
- * @param {Boolean} options.prefixAliases - Prefix column and table names with "$" to avoid conflicts in subquery expressions.
+ * @param {String} options.aliasPrefix - String to prefix to column and table names, useful to avoid conflicts in subquery expressions.
  * @param {String} options.dialect - The dialect of SQL your Database uses. Currently `'pg'`, `'oracle'`, `'mariadb'`, `'mysql'`, and `'sqlite3'` are supported.
  * @param {Object} options.dialectModule - An alternative to options.dialect. You can provide a custom implementation of one of the supported dialects.
  * @returns {Promise.<Object>} The correctly nested data from the database.
@@ -163,7 +163,7 @@ async function getNode(
       },
     },
   }
-  const namespace = new AliasNamespace(options.minify, options.prefixAliases)
+  const namespace = new AliasNamespace(options.minify, options.aliasPrefix)
   const sqlAST = {}
   const fieldNodes = resolveInfo.fieldNodes || resolveInfo.fieldASTs
   // uses the same underlying function as the main `joinMonster`

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ import {
   buildWhereFunction,
   handleUserDbCall,
   compileSqlAST,
-  getConfigFromSchemaObject
+  getConfigFromSchemaObject,
 } from './util'
 
 /*         _ _ _                _
@@ -81,6 +81,7 @@ import {
  * @param {dbCall} dbCall - A function that is passed the compiled SQL that calls the database and returns a promise of the data.
  * @param {Object} [options]
  * @param {Boolean} options.minify - Generate minimum-length column names in the results table.
+ * @param {Boolean} options.prefixAliases - Prefix column and table names with "$" to avoid conflicts in subquery expressions.
  * @param {String} options.dialect - The dialect of SQL your Database uses. Currently `'pg'`, `'oracle'`, `'mariadb'`, `'mysql'`, and `'sqlite3'` are supported.
  * @param {Object} options.dialectModule - An alternative to options.dialect. You can provide a custom implementation of one of the supported dialects.
  * @returns {Promise.<Object>} The correctly nested data from the database.
@@ -104,8 +105,8 @@ async function joinMonster(resolveInfo, context, dbCall, options = {}) {
 
   // check for batch data
   if (Array.isArray(data)) {
-    const childrenToCheck = sqlAST.children.filter(child => child.sqlBatch)
-    return data.filter(d => {
+    const childrenToCheck = sqlAST.children.filter((child) => child.sqlBatch)
+    return data.filter((d) => {
       for (const child of childrenToCheck) {
         if (d[child.fieldName] == null) {
           return false
@@ -134,14 +135,14 @@ async function getNode(
   context,
   condition,
   dbCall,
-  options = {}
+  options = {},
 ) {
   // get the GraphQL type from the schema using the name
   const type = resolveInfo.schema._typeMap[typeName]
   assert(type, `Type "${typeName}" not found in your schema.`)
   assert(
     getConfigFromSchemaObject(type).sqlTable,
-    `joinMonster can't fetch a ${typeName} as a Node unless it has "sqlTable" tagged.`
+    `joinMonster can't fetch a ${typeName} as a Node unless it has "sqlTable" tagged.`,
   )
 
   // we need to determine what the WHERE function should be
@@ -156,13 +157,13 @@ async function getNode(
         args: [],
         extensions: {
           joinMonster: {
-            where
-          }
-        }
-      }
-    }
+            where,
+          },
+        },
+      },
+    },
   }
-  const namespace = new AliasNamespace(options.minify)
+  const namespace = new AliasNamespace(options.minify, options.prefixAliases)
   const sqlAST = {}
   const fieldNodes = resolveInfo.fieldNodes || resolveInfo.fieldASTs
   // uses the same underlying function as the main `joinMonster`
@@ -174,13 +175,13 @@ async function getNode(
     namespace,
     0,
     options,
-    context
+    context,
   )
   queryAST.pruneDuplicateSqlDeps(sqlAST, namespace)
   const { sql, shapeDefinition } = await compileSqlAST(sqlAST, context, options)
   const data = arrToConnection(
     await handleUserDbCall(dbCall, sql, sqlAST, shapeDefinition),
-    sqlAST
+    sqlAST,
   )
   await nextBatch(sqlAST, data, dbCall, context, options)
   if (!data) return data

--- a/src/query-ast-to-sql-ast/index.js
+++ b/src/query-ast-to-sql-ast/index.js
@@ -95,7 +95,7 @@ export function queryASTToSqlAST(resolveInfo, options, context) {
   // force oracle to minify, because it has this 30-character limit on column identifiers
   const namespace = new AliasNamespace(
     options.dialect === 'oracle' ? true : options.minify,
-    options.prefixAliases
+    options.aliasPrefix
   )
 
   // we'll build up the AST representing the SQL recursively

--- a/src/query-ast-to-sql-ast/index.js
+++ b/src/query-ast-to-sql-ast/index.js
@@ -94,7 +94,8 @@ export function queryASTToSqlAST(resolveInfo, options, context) {
   // we need varying degrees of uniqueness and readability
   // force oracle to minify, because it has this 30-character limit on column identifiers
   const namespace = new AliasNamespace(
-    options.dialect === 'oracle' ? true : options.minify
+    options.dialect === 'oracle' ? true : options.minify,
+    options.prefixAliases
   )
 
   // we'll build up the AST representing the SQL recursively

--- a/test-api/schema-basic/QueryRoot.js
+++ b/test-api/schema-basic/QueryRoot.js
@@ -20,9 +20,10 @@ import sqlite3Module from '../../src/stringifiers/dialects/sqlite3'
 
 import joinMonster from '../../src/index'
 
-const { MINIFY, DB } = process.env
+const { MINIFY, ALIAS_PREFIX, DB } = process.env
 const options = {
-  minify: MINIFY == 1
+  minify: MINIFY == 1,
+  aliasPrefix: ALIAS_PREFIX
 }
 if (knex.client.config.client === 'mysql') {
   options.dialectModule = mysqlModule

--- a/test-api/schema-paginated/Node.js
+++ b/test-api/schema-paginated/Node.js
@@ -2,7 +2,8 @@ import { nodeDefinitions, fromGlobalId } from 'graphql-relay'
 
 import joinMonster from '../../src/index'
 const options = {
-  minify: process.env.MINIFY == 1
+  minify: process.env.MINIFY == 1,
+  aliasPrefix: process.env.ALIAS_PREFIX
 }
 const { PAGINATE } = process.env
 if (knex.client.config.client === 'mysql') {

--- a/test-api/schema-paginated/QueryRoot.js
+++ b/test-api/schema-paginated/QueryRoot.js
@@ -26,7 +26,8 @@ import { q } from '../shared'
 const { PAGINATE, DB } = process.env
 
 const options = {
-  minify: process.env.MINIFY == 1
+  minify: process.env.MINIFY == 1,
+  aliasPrefix: process.env.ALIAS_PREFIX
 }
 if (knex.client.config.client === 'mysql') {
   options.dialect = PAGINATE ? 'mysql8' : 'mysql'

--- a/test/alias-namespace.js
+++ b/test/alias-namespace.js
@@ -10,11 +10,24 @@ test(`it should generate a minified table alias`, t => {
   t.is(ns.generate('table', 'users'), 'b')
 })
 
+test(`it should generate a minified, prefixed table alias`, t => {
+  const ns = new AliasNamespace(true, '$')
+  t.is(ns.generate('table', 'users'), '$a')
+  t.is(ns.generate('table', 'users'), '$b')
+})
+
 test(`it should generate a minified column alias`, t => {
   // columns are cached by name and reused
   const ns = new AliasNamespace(true)
   t.is(ns.generate('column', 'firstname'), 'a')
   t.is(ns.generate('column', 'firstname'), 'a')
+})
+
+test(`it should generate a minified, prefixed column alias`, t => {
+  // columns are cached by name and reused
+  const ns = new AliasNamespace(true, '$')
+  t.is(ns.generate('column', 'firstname'), '$a')
+  t.is(ns.generate('column', 'firstname'), '$a')
 })
 
 test(`it should generate an unminified table alias`, t => {
@@ -24,6 +37,13 @@ test(`it should generate an unminified table alias`, t => {
   t.is(ns.generate('table', 'users'), 'users$$')
 })
 
+test(`it should generate an unminified, prefixed table alias`, t => {
+  const ns = new AliasNamespace(false, '$')
+  t.is(ns.generate('table', 'users'), '$users')
+  t.is(ns.generate('table', 'users'), '$users$')
+  t.is(ns.generate('table', 'users'), '$users$$')
+})
+
 test(`it should generate an unminified column alias`, t => {
   // columns are cached by name and reused
   const ns = new AliasNamespace(false)
@@ -31,10 +51,23 @@ test(`it should generate an unminified column alias`, t => {
   t.is(ns.generate('column', 'firstname'), 'firstname')
 })
 
+test(`it should generate an unminified, prefixed column alias`, t => {
+  // columns are cached by name and reused
+  const ns = new AliasNamespace(false, '$')
+  t.is(ns.generate('column', 'firstname'), '$firstname')
+  t.is(ns.generate('column', 'firstname'), '$firstname')
+})
+
 test(`it should generate an unminified table alias (diffenent names won't collapse to alias)`, t => {
   const ns = new AliasNamespace(false)
   t.is(ns.generate('table', 'InformationItem'), 'Informatio')
   t.is(ns.generate('table', 'InformationItemHasGroup'), 'Informatio$')
+})
+
+test(`it should generate an unminified, prefixed table alias (diffenent names won't collapse to alias)`, t => {
+  const ns = new AliasNamespace(false)
+  t.is(ns.generate('table', 'InformationItem'), '$Informati')
+  t.is(ns.generate('table', 'InformationItemHasGroup'), '$Informati$')
 })
 
 if (process.env.DB === 'PG' && !process.env.STRATEGY && !process.env.MINIFY) {

--- a/test/alias-namespace.js
+++ b/test/alias-namespace.js
@@ -23,11 +23,11 @@ test(`it should generate a minified column alias`, t => {
   t.is(ns.generate('column', 'firstname'), 'a')
 })
 
-test(`it should generate a minified, prefixed column alias`, t => {
+test(`it should generate a minified, non-prefixed column alias`, t => {
   // columns are cached by name and reused
   const ns = new AliasNamespace(true, '$')
-  t.is(ns.generate('column', 'firstname'), '$a')
-  t.is(ns.generate('column', 'firstname'), '$a')
+  t.is(ns.generate('column', 'firstname'), 'a')
+  t.is(ns.generate('column', 'firstname'), 'a')
 })
 
 test(`it should generate an unminified table alias`, t => {
@@ -51,11 +51,11 @@ test(`it should generate an unminified column alias`, t => {
   t.is(ns.generate('column', 'firstname'), 'firstname')
 })
 
-test(`it should generate an unminified, prefixed column alias`, t => {
+test(`it should generate an unminified, non-prefixed column alias`, t => {
   // columns are cached by name and reused
   const ns = new AliasNamespace(false, '$')
-  t.is(ns.generate('column', 'firstname'), '$firstname')
-  t.is(ns.generate('column', 'firstname'), '$firstname')
+  t.is(ns.generate('column', 'firstname'), 'firstname')
+  t.is(ns.generate('column', 'firstname'), 'firstname')
 })
 
 test(`it should generate an unminified table alias (diffenent names won't collapse to alias)`, t => {
@@ -65,9 +65,9 @@ test(`it should generate an unminified table alias (diffenent names won't collap
 })
 
 test(`it should generate an unminified, prefixed table alias (diffenent names won't collapse to alias)`, t => {
-  const ns = new AliasNamespace(false)
-  t.is(ns.generate('table', 'InformationItem'), '$Informati')
-  t.is(ns.generate('table', 'InformationItemHasGroup'), '$Informati$')
+  const ns = new AliasNamespace(false, '$')
+  t.is(ns.generate('table', 'InformationItem'), '$Informatio')
+  t.is(ns.generate('table', 'InformationItemHasGroup'), '$Informatio$')
 })
 
 if (process.env.DB === 'PG' && !process.env.STRATEGY && !process.env.MINIFY) {


### PR DESCRIPTION
### Description

Adds an optional `prefixAliases` property to the join-monster options object. When set to true, table and column aliases are prefixed with "$" to avoid conflicting with commonly used single-letter aliases defined in where/join subqueries.

### References

- #532

### Testing

No change when prefixAliases is omitted. When specified, generated SQL queries contain the prefixed string.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR via comments and by updating the change log
