### PR TITLE
alwaysFetch functionality for junction tables 

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Run Tests
         run: npm test
         
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: npm-logs

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### vNEXT 
 #### Fixed
+- [#549](https://github.com/join-monster/join-monster/pull/549): Fix alwaysFetch for junction clause.
 - [#539](https://github.com/join-monster/join-monster/pull/539): Do not rely on test-api for order tests setup.
 - [#538](https://github.com/join-monster/join-monster/pull/538): Refactor: cleanup code around sorting.
 - [#537](https://github.com/join-monster/join-monster/pull/537): Fix for messed up files syntax.

--- a/src/query-ast-to-sql-ast/index.js
+++ b/src/query-ast-to-sql-ast/index.js
@@ -496,7 +496,7 @@ function handleTable(
       columnChild.fromOtherTable = sqlASTNode.junction.as
     
       // Add directly to children at this point, after all standard columns
-      sqlASTNode.children.push(columnChild);
+      sqlASTNode.children.push(columnChild)
     }
   }
 

--- a/test-api/schema-basic/QueryRoot.js
+++ b/test-api/schema-basic/QueryRoot.js
@@ -103,16 +103,6 @@ export default new GraphQLObjectType({
           }
         }
       },
-    /*****
-      resolve: (parent, args, context, resolveInfo) => {
-        return joinMonster(
-          resolveInfo,
-          context,
-          sql => dbCall(sql, knex, context),
-          options
-        )
-      }
-    ******/
       resolve: (parent, args, context, resolveInfo) => {
          // Add a hook to capture the SQL
     

--- a/test-api/schema-basic/QueryRoot.js
+++ b/test-api/schema-basic/QueryRoot.js
@@ -103,12 +103,32 @@ export default new GraphQLObjectType({
           }
         }
       },
+    /*****
       resolve: (parent, args, context, resolveInfo) => {
         return joinMonster(
           resolveInfo,
           context,
           sql => dbCall(sql, knex, context),
           options
+        )
+      }
+    ******/
+      resolve: (parent, args, context, resolveInfo) => {
+         // Add a hook to capture the SQL
+    
+         const sqlLogger = sql => {
+         // Store it in the context for the test to access
+            if (context && Object.prototype.hasOwnProperty.call(context, 'capturedSql')) {
+               context.capturedSql = sql
+            }
+            return dbCall(sql, knex, context)
+         }
+
+         return joinMonster(
+            resolveInfo,
+            context,
+            sqlLogger,
+            options
         )
       }
     },

--- a/test-api/schema-basic/User.js
+++ b/test-api/schema-basic/User.js
@@ -170,6 +170,7 @@ const User = new GraphQLObjectType({
               : false,
           junction: {
             sqlTable: q('relationships', DB),
+            alwaysFetch: ['closeness'],
             orderBy: args =>
               args.oldestFirst ? { followee_id: 'desc' } : null,
             where: (table, args) =>

--- a/test-api/schema-paginated/QueryRoot.js
+++ b/test-api/schema-paginated/QueryRoot.js
@@ -132,11 +132,21 @@ export default new GraphQLObjectType({
         }
       },
       resolve: (parent, args, context, resolveInfo) => {
-        return joinMonster(
-          resolveInfo,
-          context,
-          sql => dbCall(sql, knex, context),
-          options
+         // Add a hook to capture the SQL
+
+         const sqlLogger = sql => {
+         // Store it in the context for the test to access
+            if (context && Object.prototype.hasOwnProperty.call(context, 'capturedSql')) {
+               context.capturedSql = sql
+            }
+            return dbCall(sql, knex, context)
+         }
+
+         return joinMonster(
+            resolveInfo,
+            context, 
+            sqlLogger,
+            options
         )
       }
     },

--- a/test-api/schema-paginated/User.js
+++ b/test-api/schema-paginated/User.js
@@ -241,6 +241,7 @@ const User = new GraphQLObjectType({
           ),
           junction: {
             sqlTable: `(SELECT * FROM ${q('relationships', DB)})`,
+            alwaysFetch: ['closeness'],
             where: (table, args) =>
               args.intimacy
                 ? `${table}.${q('closeness', DB)} = '${args.intimacy}'`

--- a/test/junctions.js
+++ b/test/junctions.js
@@ -33,3 +33,25 @@ test('should handle data from the junction table', async t => {
   }
   t.deepEqual(expect, data)
 })
+
+test('should include alwaysFetch columns from junction table in SQL', async t => {
+  const context = { capturedSql: '' }
+  
+  const source = `{
+    user(id: 3) {
+      fullName
+      following {
+        id
+      }
+    }
+  }`
+  
+  
+  await graphql({schema, source, contextValue: context})
+  
+  // Now check the captured SQL
+  console.log(`context = ${JSON.stringify(context)}`)
+  console.log(`SQL = ${context.capturedSql}`)
+  t.true(context.capturedSql.includes('closeness'), 'SQL should include the closeness column')
+})
+

--- a/test/junctions.js
+++ b/test/junctions.js
@@ -50,8 +50,6 @@ test('should include alwaysFetch columns from junction table in SQL', async t =>
   await graphql({schema, source, contextValue: context})
   
   // Now check the captured SQL
-  console.log(`context = ${JSON.stringify(context)}`)
-  console.log(`SQL = ${context.capturedSql}`)
   t.true(context.capturedSql.includes('closeness'), 'SQL should include the closeness column')
 })
 


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Code of Conduct](https://github.com/join-monster/join-monster/blob/master/CODE_OF_CONDUCT.md). Please see the [contributing guidelines](https://github.com/join-monster/join-monster/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

The junction table functionality of join-monster exposes the alwaysFetch capability but did not implement it. It silently fails to do anything. When needing to leverage columns from the junction table the developer is left only with the "junction include" functionality which may force an unneeded change to the graphQL schema. The alwaysFetch capability allows columns to be referenced to influence business logic. The lack of support in junction tables seems to have been an oversight.

So in this PR we add the functionality for junction tables that had already been exposed but unimplemented. This requires no change in the documentation.

There was also an issue with the CI pipeline unrelated to these changes that was causing the pipeline to fail. This has been fixed in this PR as well.

### References
https://github.com/join-monster/join-monster/issues/548


### Testing

The current PR adds a simple test to ensure that the column is added to the select list and that the column isn't the first one in the select list (as the first one in the select list for junction tables is used as a key). In addition, all tests pass.  

- [x ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x ] I have added documentation for new/changed functionality in this PR via comments and by updating the change log
